### PR TITLE
Dependencies in setup.py

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install .
           pip install pytest
 
       - name: Run tests with Pytest

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,13 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    install_requires=[
+        "tqdm",
+        "numpy",
+        "torch>=2.0.1",
+        "coverage",
+        "pytest"
+    ]
     python_requires=">=3.8",
     package_dir={"":"src"}
 )


### PR DESCRIPTION
The package's dependencies have been added in the `install_requires` field of `setup.py` and the CI now install them using `pip install .` instead of `pip install -r requirements.txt` to simulate a `pip install simulated-bifurcation` from a user.