### PR TITLE
Ising polynomial interface device and dtype conversion

### DIFF
--- a/.github/scripts/metadata_checker/metadata_checker.py
+++ b/.github/scripts/metadata_checker/metadata_checker.py
@@ -102,7 +102,7 @@ def action_set(
 
 
 def action_begin(
-    lines: list[str],
+    lines: List[str],
     enumerate_lines: Iterator[Tuple[int, str]],
     begin_args: str,
     variables: Dict[str, List[Tuple[str, int]]],

--- a/src/simulated_bifurcation/polynomial/ising_polynomial_interface.py
+++ b/src/simulated_bifurcation/polynomial/ising_polynomial_interface.py
@@ -228,6 +228,21 @@ class IsingPolynomialInterface(ABC):
                 f"Vector must be of size {self.dimension}, got {vector.shape}."
             )
 
+    @final
+    def to(
+        self,
+        device: Optional[Union[str, torch.device]] = None,
+        dtype: Optional[torch.dtype] = None,
+    ) -> None:
+        args = {}
+        if device is not None:
+            args["device"] = device
+        if dtype is not None:
+            args["dtype"] = dtype
+        self.__matrix = self.__matrix.to(**args)
+        self.__vector = self.__vector.to(**args)
+        self.__constant = self.__constant.to(**args)
+
     @abstractmethod
     def to_ising(self) -> IsingCore:
         """

--- a/src/simulated_bifurcation/polynomial/ising_polynomial_interface.py
+++ b/src/simulated_bifurcation/polynomial/ising_polynomial_interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Iterable, Optional, Tuple, Union, final
+from typing import Iterable, List, Optional, Tuple, Union, final
 
 import numpy as np
 import torch
@@ -27,7 +27,7 @@ class IsingPolynomialInterface(ABC):
         matrix: Union[torch.Tensor, np.ndarray],
         vector: Union[torch.Tensor, np.ndarray, None] = None,
         constant: Union[int, float, None] = None,
-        accepted_values: Union[torch.Tensor, np.ndarray, list[int], None] = None,
+        accepted_values: Union[torch.Tensor, np.ndarray, List[int], None] = None,
         dtype: torch.dtype = torch.float32,
         device: str = "cpu",
     ) -> None:

--- a/src/tests/test_spin_polynomial.py
+++ b/src/tests/test_spin_polynomial.py
@@ -63,3 +63,25 @@ def test_optimize_spin_polynomial():
     spin_vars, value = spin_polynomial.optimize(verbose=False)
     assert torch.equal(spin_vars, torch.tensor([1, -1, 1], dtype=torch.float32))
     assert value == -11.0
+
+
+def test_to():
+    spin_polynomial = SpinPolynomial(matrix, vector, constant)
+    assert spin_polynomial.dtype == torch.float32
+    assert spin_polynomial.device == torch.device("cpu")
+
+    spin_polynomial.to(dtype=torch.float16)
+    assert spin_polynomial.dtype == torch.float16
+    assert spin_polynomial.device == torch.device("cpu")
+
+    spin_polynomial.to(device="cpu")
+    assert spin_polynomial.dtype == torch.float16
+    assert spin_polynomial.device == torch.device("cpu")
+
+    spin_polynomial.to(device="cpu", dtype=torch.float64)
+    assert spin_polynomial.dtype == torch.float64
+    assert spin_polynomial.device == torch.device("cpu")
+
+    spin_polynomial.to()
+    assert spin_polynomial.dtype == torch.float64
+    assert spin_polynomial.device == torch.device("cpu")

--- a/src/tests/test_spin_polynomial.py
+++ b/src/tests/test_spin_polynomial.py
@@ -67,21 +67,27 @@ def test_optimize_spin_polynomial():
 
 def test_to():
     spin_polynomial = SpinPolynomial(matrix, vector, constant)
-    assert spin_polynomial.dtype == torch.float32
-    assert spin_polynomial.device == torch.device("cpu")
+
+    def check_device_and_dtype(dtype: torch.dtype):
+        assert spin_polynomial.dtype == dtype
+        assert spin_polynomial.device == torch.device("cpu")
+        assert spin_polynomial.matrix.dtype == dtype
+        assert spin_polynomial.vector.dtype == dtype
+        assert spin_polynomial.constant.dtype == dtype
+        assert spin_polynomial.matrix.device == torch.device("cpu")
+        assert spin_polynomial.vector.device == torch.device("cpu")
+        assert spin_polynomial.constant.device == torch.device("cpu")
+
+    check_device_and_dtype(torch.float32)
 
     spin_polynomial.to(dtype=torch.float16)
-    assert spin_polynomial.dtype == torch.float16
-    assert spin_polynomial.device == torch.device("cpu")
+    check_device_and_dtype(torch.float16)
 
     spin_polynomial.to(device="cpu")
-    assert spin_polynomial.dtype == torch.float16
-    assert spin_polynomial.device == torch.device("cpu")
+    check_device_and_dtype(torch.float16)
 
     spin_polynomial.to(device="cpu", dtype=torch.float64)
-    assert spin_polynomial.dtype == torch.float64
-    assert spin_polynomial.device == torch.device("cpu")
+    check_device_and_dtype(torch.float64)
 
     spin_polynomial.to()
-    assert spin_polynomial.dtype == torch.float64
-    assert spin_polynomial.device == torch.device("cpu")
+    check_device_and_dtype(torch.float64)


### PR DESCRIPTION
## PR Description

Inspired by [PyTorch API](https://pytorch.org/docs/stable/generated/torch.Tensor.to.html), the `IsingPolynomialInterface`, and thus all the polynomials (spin, binary, integer) provided by the package have a `to(device: torch.device, dtype: torch.dtype)` method to convert its tensors dtype and change the computation device in place.

## New features

- `IsingPolynomialInterface.to(device: torch.device, dtype: torch.dtype)` method to change the dtype and computation device in place (both arguments are optional)