### PR TITLE
Deprecate polynomials

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,9 +229,9 @@ A lot of mathematical problems (QUBO, Travelling Salesman Problem, MAXCUT, ...) 
 
 ### Custom models
 
-You are also free to create your own models using our API. Depending on the type of model you wish to implement, you cen create a subclass of one of the `SpinPolynomial`, `BinaryPolynomial` or `IntegerPolynomial` APIs to quickly and efficiently link your custom model to an Ising problem and solve it using the SB algorithm.
+You are also free to create your own models using our API. Depending on the type of model you wish to implement, you cen create a subclass of one of the `SpinQuadraticPolynomial`, `BinaryQuadraticPolynomial` or `IntegerQuadraticPolynomial` APIs to quickly and efficiently link your custom model to an Ising problem and solve it using the SB algorithm.
 
-The advantage of doing so is that your model can directly call the `optimize` method that it inherits from the `BaseMultivariatePolynomial` interface without having to redefine it.
+The advantage of doing so is that your model can directly call the `optimize` method that it inherits from the `BaseMultivariateQuadraticPolynomial` interface without having to redefine it.
 
 For instance, here is how the QUBO model was implemented:
 
@@ -239,10 +239,10 @@ For instance, here is how the QUBO model was implemented:
 > $$\sum_{i=1}^{N} \sum_{j=1}^{N} Q_{ij}x_{i}x_{j}$$
 
 ```python
-from simulated_bifurcation import BinaryPolynomial
+from simulated_bifurcation import BinaryQuadraticPolynomial
 
 
-class QUBO(BinaryPolynomial):
+class QUBO(BinaryQuadraticPolynomial):
 
     def __init__(self, Q, dtype, device) -> None:
         super().__init__(matrix=Q, vector=None, constant=None,

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ A lot of mathematical problems (QUBO, Travelling Salesman Problem, MAXCUT, ...) 
 
 You are also free to create your own models using our API. Depending on the type of model you wish to implement, you cen create a subclass of one of the `SpinPolynomial`, `BinaryPolynomial` or `IntegerPolynomial` APIs to quickly and efficiently link your custom model to an Ising problem and solve it using the SB algorithm.
 
-The advantage of doing so is that your model can directly call the `optimize` method that it inherits from the `IsingPolynomialInterface` interface without having to redefine it.
+The advantage of doing so is that your model can directly call the `optimize` method that it inherits from the `BaseMultivariatePolynomial` interface without having to redefine it.
 
 For instance, here is how the QUBO model was implemented:
 

--- a/src/simulated_bifurcation/__init__.py
+++ b/src/simulated_bifurcation/__init__.py
@@ -143,8 +143,11 @@ tensor([0., 0.], device='cuda:0')
 from . import models
 from .optimizer import get_env, reset_env, set_env
 from .polynomial import (
+    BinaryPolynomial,
     BinaryQuadraticPolynomial,
+    IntegerPolynomial,
     IntegerQuadraticPolynomial,
+    SpinPolynomial,
     SpinQuadraticPolynomial,
 )
 from .simulated_bifurcation import build_model, maximize, minimize, optimize

--- a/src/simulated_bifurcation/__init__.py
+++ b/src/simulated_bifurcation/__init__.py
@@ -24,7 +24,7 @@ Several common combinatorial optimization problems are reframed as Ising
 problems in the `models` module, e.g.: QUBO, knapsack, Markowitz model...
 Polynomials over vectors whose entries are in {0, 1} or whose entries are
 fixed bit-width integers are also implemented, as well as an abstract
-polynomial class `BaseMultivariatePolynomial` for further customization.
+polynomial class `BaseMultivariateQuadraticPolynomial` for further customization.
 
 The docstring examples assume that `torch` (PyTorch) has been imported and
 that simulated_bifurcation has been imported as `sb`:
@@ -142,7 +142,11 @@ tensor([0., 0.], device='cuda:0')
 
 from . import models
 from .optimizer import get_env, reset_env, set_env
-from .polynomial import BinaryPolynomial, IntegerPolynomial, SpinPolynomial
+from .polynomial import (
+    BinaryQuadraticPolynomial,
+    IntegerQuadraticPolynomial,
+    SpinQuadraticPolynomial,
+)
 from .simulated_bifurcation import build_model, maximize, minimize, optimize
 
 reset_env()

--- a/src/simulated_bifurcation/__init__.py
+++ b/src/simulated_bifurcation/__init__.py
@@ -24,7 +24,7 @@ Several common combinatorial optimization problems are reframed as Ising
 problems in the `models` module, e.g.: QUBO, knapsack, Markowitz model...
 Polynomials over vectors whose entries are in {0, 1} or whose entries are
 fixed bit-width integers are also implemented, as well as an abstract
-polynomial class `IsingPolynomialInterface` for further customization.
+polynomial class `BaseMultivariatePolynomial` for further customization.
 
 The docstring examples assume that `torch` (PyTorch) has been imported and
 that simulated_bifurcation has been imported as `sb`:

--- a/src/simulated_bifurcation/__init__.py
+++ b/src/simulated_bifurcation/__init__.py
@@ -37,6 +37,17 @@ Code snippets are indicated by three greater-than signs:
   >>> x = 42
   >>> x = x + 1
 
+.. deprecated:: 1.2.1
+    `BinaryPolynomial` will be modified in simulated-bifurcation 1.3.0, it
+    is replaced by `BinaryQuadraticPolynomial` in prevision of the addition
+    of multivariate polynomials of an arbitrary degree.
+    `IntegerPolynomial` will be modified in simulated-bifurcation 1.3.0, it
+    is replaced by `IntegerQuadraticPolynomial` in prevision of the
+    addition of multivariate polynomials of an arbitrary degree.
+    `SpinPolynomial` will be modified in simulated-bifurcation 1.3.0, it is
+    replaced by `SpinQuadraticPolynomial` in prevision of the addition of
+    multivariate polynomials of an arbitrary degree.
+
 Notes
 -----
 The SB algorithm is an approximation algorithm, which implies that the

--- a/src/simulated_bifurcation/ising_core.py
+++ b/src/simulated_bifurcation/ising_core.py
@@ -10,7 +10,7 @@ See Also
 models.Ising:
     Implementation of the Ising model which behaves like other models and
     polynomials.
-IsingPolynomialInterface: Abstract multivariate polynomial class.
+BaseMultivariatePolynomial: Abstract multivariate polynomial class.
 
 """
 
@@ -338,7 +338,7 @@ class IsingCore:
         models.Ising:
             Implementation of the Ising model which behaves like other
             models and polynomials.
-        IsingPolynomialInterface: Abstract multivariate polynomial class.
+        BaseMultivariatePolynomial: Abstract multivariate polynomial class.
 
         Notes
         -----

--- a/src/simulated_bifurcation/ising_core.py
+++ b/src/simulated_bifurcation/ising_core.py
@@ -10,7 +10,7 @@ See Also
 models.Ising:
     Implementation of the Ising model which behaves like other models and
     polynomials.
-BaseMultivariatePolynomial: Abstract multivariate polynomial class.
+BaseMultivariateQuadraticPolynomial: Abstract multivariate polynomial class.
 
 """
 
@@ -338,7 +338,7 @@ class IsingCore:
         models.Ising:
             Implementation of the Ising model which behaves like other
             models and polynomials.
-        BaseMultivariatePolynomial: Abstract multivariate polynomial class.
+        BaseMultivariateQuadraticPolynomial: Abstract multivariate polynomial class.
 
         Notes
         -----

--- a/src/simulated_bifurcation/models/ising.py
+++ b/src/simulated_bifurcation/models/ising.py
@@ -3,10 +3,10 @@ from typing import Union
 import numpy as np
 import torch
 
-from ..polynomial import SpinPolynomial
+from ..polynomial import SpinQuadraticPolynomial
 
 
-class Ising(SpinPolynomial):
+class Ising(SpinQuadraticPolynomial):
 
     """
     Implementation of the Ising model.

--- a/src/simulated_bifurcation/models/knapsack.py
+++ b/src/simulated_bifurcation/models/knapsack.py
@@ -3,10 +3,10 @@ from typing import Dict, List, Union
 import numpy as np
 import torch
 
-from ..polynomial import BinaryPolynomial
+from ..polynomial import BinaryQuadraticPolynomial
 
 
-class Knapsack(BinaryPolynomial):
+class Knapsack(BinaryQuadraticPolynomial):
     def __init__(
         self,
         weights: List[int],

--- a/src/simulated_bifurcation/models/markowitz.py
+++ b/src/simulated_bifurcation/models/markowitz.py
@@ -3,10 +3,10 @@ from typing import Optional, Tuple, Union
 import numpy as np
 import torch
 
-from ..polynomial import IntegerPolynomial
+from ..polynomial import IntegerQuadraticPolynomial
 
 
-class SequentialMarkowitz(IntegerPolynomial):
+class SequentialMarkowitz(IntegerQuadraticPolynomial):
     def __init__(
         self,
         covariances: Union[torch.Tensor, np.ndarray],

--- a/src/simulated_bifurcation/models/number_partitioning.py
+++ b/src/simulated_bifurcation/models/number_partitioning.py
@@ -3,10 +3,10 @@ from typing import Dict, List, Union
 import torch
 from numpy import sum
 
-from ..polynomial import SpinPolynomial
+from ..polynomial import SpinQuadraticPolynomial
 
 
-class NumberPartitioning(SpinPolynomial):
+class NumberPartitioning(SpinQuadraticPolynomial):
 
     """
     A solver that separates a set of numbers into two subsets, the

--- a/src/simulated_bifurcation/models/qubo.py
+++ b/src/simulated_bifurcation/models/qubo.py
@@ -3,10 +3,10 @@ from typing import Union
 import numpy as np
 import torch
 
-from ..polynomial import BinaryPolynomial
+from ..polynomial import BinaryQuadraticPolynomial
 
 
-class QUBO(BinaryPolynomial):
+class QUBO(BinaryQuadraticPolynomial):
 
     """
     Quadratic Unconstrained Binary Optimization

--- a/src/simulated_bifurcation/polynomial/__init__.py
+++ b/src/simulated_bifurcation/polynomial/__init__.py
@@ -11,18 +11,18 @@ the polynomial is said to be defined over a domain.
 
 Available classes
 -----------------
-BaseMultivariatePolynomial:
+BaseMultivariateQuadraticPolynomial:
     Abstract class for multivariate degree 2 polynomials.
-BinaryPolynomial:
+BinaryQuadraticPolynomial:
     Multivariate degree 2 polynomials over vectors whose entries are in
     {0, 1}.
-IntegerPolynomial:
+IntegerQuadraticPolynomial:
     Multivariate degree 2 polynomials over non-negative integers with a
     fixed number of bits. For instance, a polynomial over 7-bits integers
     is a polynomial whose domain is the set of vectors whose entries are
     all 7-bits integers, that is integer between 1 and 2^7 - 1 = 127
     (inclusive).
-SpinPolynomial:
+SpinQuadraticPolynomial:
     Multivariate degree 2 polynomials over vectors whose entries are in
     {-1, 1}.
 
@@ -37,7 +37,7 @@ models:
 """
 
 
-from .base_multivariate_polynomial import BaseMultivariatePolynomial
-from .binary_polynomial import BinaryPolynomial
-from .integer_polynomial import IntegerPolynomial
-from .spin_polynomial import SpinPolynomial
+from .base_multivariate_polynomial import BaseMultivariateQuadraticPolynomial
+from .binary_polynomial import BinaryQuadraticPolynomial
+from .integer_polynomial import IntegerQuadraticPolynomial
+from .spin_polynomial import SpinQuadraticPolynomial

--- a/src/simulated_bifurcation/polynomial/__init__.py
+++ b/src/simulated_bifurcation/polynomial/__init__.py
@@ -1,6 +1,21 @@
 """
 Implementation of multivariate degree 2 polynomials.
 
+.. deprecated:: 1.2.1
+    `IsingPolynomialInterface` will be removed in simulated-bifurcation
+    1.3.0, it is replaced by `BaseMultivariateQuadraticPolynomial` in
+    prevision of the addition of multivariate polynomials of an arbitrary
+    degree.
+    `BinaryPolynomial` will be modified in simulated-bifurcation 1.3.0, it
+    is replaced by `BinaryQuadraticPolynomial` in prevision of the addition
+    of multivariate polynomials of an arbitrary degree.
+    `IntegerPolynomial` will be modified in simulated-bifurcation 1.3.0, it
+    is replaced by `IntegerQuadraticPolynomial` in prevision of the
+    addition of multivariate polynomials of an arbitrary degree.
+    `SpinPolynomial` will be modified in simulated-bifurcation 1.3.0, it is
+    replaced by `SpinQuadraticPolynomial` in prevision of the addition of
+    multivariate polynomials of an arbitrary degree.
+
 Multivariate degree 2 polynomials are the sum of a quadratic form and a
 linear form plus a constant term:
 `ΣΣ Q(i,j)x(i)x(j) + Σ l(i)x(i) + c`

--- a/src/simulated_bifurcation/polynomial/__init__.py
+++ b/src/simulated_bifurcation/polynomial/__init__.py
@@ -11,7 +11,7 @@ the polynomial is said to be defined over a domain.
 
 Available classes
 -----------------
-IsingPolynomialInterface:
+BaseMultivariatePolynomial:
     Abstract class for multivariate degree 2 polynomials.
 BinaryPolynomial:
     Multivariate degree 2 polynomials over vectors whose entries are in
@@ -37,7 +37,7 @@ models:
 """
 
 
+from .base_multivariate_polynomial import BaseMultivariatePolynomial
 from .binary_polynomial import BinaryPolynomial
 from .integer_polynomial import IntegerPolynomial
-from .ising_polynomial_interface import IsingPolynomialInterface
 from .spin_polynomial import SpinPolynomial

--- a/src/simulated_bifurcation/polynomial/__init__.py
+++ b/src/simulated_bifurcation/polynomial/__init__.py
@@ -37,7 +37,10 @@ models:
 """
 
 
-from .base_multivariate_polynomial import BaseMultivariateQuadraticPolynomial
-from .binary_polynomial import BinaryQuadraticPolynomial
-from .integer_polynomial import IntegerQuadraticPolynomial
-from .spin_polynomial import SpinQuadraticPolynomial
+from .base_multivariate_polynomial import (
+    BaseMultivariateQuadraticPolynomial,
+    IsingPolynomialInterface,
+)
+from .binary_polynomial import BinaryPolynomial, BinaryQuadraticPolynomial
+from .integer_polynomial import IntegerPolynomial, IntegerQuadraticPolynomial
+from .spin_polynomial import SpinPolynomial, SpinQuadraticPolynomial

--- a/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
@@ -7,7 +7,7 @@ import torch
 from ..ising_core import IsingCore
 
 
-class BaseMultivariatePolynomial(ABC):
+class BaseMultivariateQuadraticPolynomial(ABC):
 
     """
     Abstract class to implement an order two multivariate polynomial that can

--- a/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC, abstractmethod
 from typing import Iterable, List, Optional, Tuple, Union, final
 
@@ -606,5 +607,12 @@ class BaseMultivariateQuadraticPolynomial(ABC):
 
 class IsingPolynomialInterface(BaseMultivariateQuadraticPolynomial, ABC):
     def __init__(self, *args, **kwargs) -> None:
-        # TODO: deprecation warning
+        # 2023-10-03, 1.2.1
+        warnings.warn(
+            "`IsingPolynomialInterface` is deprecated as of simulated-bifurcation "
+            "1.2.1, and will be removed in simulated-bifurcation 1.3.0. Please use "
+            "`BaseQuadraticMultivariatePolynomial` instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
         super().__init__(*args, **kwargs)

--- a/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
@@ -1,3 +1,13 @@
+"""
+.. deprecated:: 1.2.1
+    `IsingPolynomialInterface` will be removed in simulated-bifurcation
+    1.3.0, it is replaced by `BaseMultivariateQuadraticPolynomial` in
+    prevision of the addition of multivariate polynomials of an arbitrary
+    degree.
+
+"""
+
+
 import warnings
 from abc import ABC, abstractmethod
 from typing import Iterable, List, Optional, Tuple, Union, final
@@ -606,6 +616,16 @@ class BaseMultivariateQuadraticPolynomial(ABC):
 
 
 class IsingPolynomialInterface(BaseMultivariateQuadraticPolynomial, ABC):
+
+    """
+    .. deprecated:: 1.2.1
+        `IsingPolynomialInterface` will be removed in simulated-bifurcation
+        1.3.0, it is replaced by `BaseMultivariateQuadraticPolynomial` in
+        prevision of the addition of multivariate polynomials of an
+        arbitrary degree.
+
+    """
+
     def __init__(self, *args, **kwargs) -> None:
         # 2023-10-03, 1.2.1
         warnings.warn(

--- a/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
@@ -7,7 +7,7 @@ import torch
 from ..ising_core import IsingCore
 
 
-class IsingPolynomialInterface(ABC):
+class BaseMultivariatePolynomial(ABC):
 
     """
     Abstract class to implement an order two multivariate polynomial that can

--- a/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
@@ -602,3 +602,9 @@ class BaseMultivariateQuadraticPolynomial(ABC):
             convergence_threshold=convergence_threshold,
             timeout=timeout,
         )
+
+
+class IsingPolynomialInterface(BaseMultivariateQuadraticPolynomial, ABC):
+    def __init__(self, *args, **kwargs) -> None:
+        # TODO: deprecation warning
+        super().__init__(*args, **kwargs)

--- a/src/simulated_bifurcation/polynomial/binary_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/binary_polynomial.py
@@ -28,6 +28,7 @@ models:
 
 """
 
+import warnings
 from typing import Optional, Union
 
 import numpy as np
@@ -144,5 +145,12 @@ class BinaryQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
 
 class BinaryPolynomial(BinaryQuadraticPolynomial):
     def __init__(self, *args, **kwargs) -> None:
-        # TODO: deprecation warning
+        # 2023-10-03, 1.2.1
+        warnings.warn(
+            "`BinaryPolynomial` is deprecated as of simulated-bifurcation 1.2.1, and "
+            "its behaviour will change in simulated-bifurcation 1.3.0. Please use "
+            "`BinaryQuadraticPolynomial` instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
         super().__init__(*args, **kwargs)

--- a/src/simulated_bifurcation/polynomial/binary_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/binary_polynomial.py
@@ -140,3 +140,9 @@ class BinaryQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
         else:
             binary_vars = None
         return binary_vars
+
+
+class BinaryPolynomial(BinaryQuadraticPolynomial):
+    def __init__(self, *args, **kwargs) -> None:
+        # TODO: deprecation warning
+        super().__init__(*args, **kwargs)

--- a/src/simulated_bifurcation/polynomial/binary_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/binary_polynomial.py
@@ -13,7 +13,7 @@ solved with the Simulated Bifurcation algorithm.
 
 See Also
 --------
-IsingPolynomialInterface:
+BaseMultivariatePolynomial:
     Abstract class for multivariate degree 2 polynomials.
 IntegerPolynomial:
     Multivariate degree 2 polynomials over non-negative integers with a
@@ -34,10 +34,10 @@ import numpy as np
 import torch
 
 from ..ising_core import IsingCore
-from .ising_polynomial_interface import IsingPolynomialInterface
+from .base_multivariate_polynomial import BaseMultivariatePolynomial
 
 
-class BinaryPolynomial(IsingPolynomialInterface):
+class BinaryPolynomial(BaseMultivariatePolynomial):
 
     """
     Multivariate degree 2 polynomials over binary vectors.
@@ -85,7 +85,7 @@ class BinaryPolynomial(IsingPolynomialInterface):
 
     See Also
     --------
-    IsingPolynomialInterface:
+    BaseMultivariatePolynomial:
         Abstract class for multivariate degree 2 polynomials.
     IntegerPolynomial:
         Multivariate degree 2 polynomials over non-negative integers with a

--- a/src/simulated_bifurcation/polynomial/binary_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/binary_polynomial.py
@@ -13,12 +13,12 @@ solved with the Simulated Bifurcation algorithm.
 
 See Also
 --------
-BaseMultivariatePolynomial:
+BaseMultivariateQuadraticPolynomial:
     Abstract class for multivariate degree 2 polynomials.
-IntegerPolynomial:
+IntegerQuadraticPolynomial:
     Multivariate degree 2 polynomials over non-negative integers with a
     fixed number of bits.
-SpinPolynomial:
+SpinQuadraticPolynomial:
     Multivariate degree 2 polynomials over vectors whose entries are in
     {-1, 1}.
 models.QUBO: Implementation of the QUBO problem.
@@ -34,10 +34,10 @@ import numpy as np
 import torch
 
 from ..ising_core import IsingCore
-from .base_multivariate_polynomial import BaseMultivariatePolynomial
+from .base_multivariate_polynomial import BaseMultivariateQuadraticPolynomial
 
 
-class BinaryPolynomial(BaseMultivariatePolynomial):
+class BinaryQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
 
     """
     Multivariate degree 2 polynomials over binary vectors.
@@ -85,12 +85,12 @@ class BinaryPolynomial(BaseMultivariatePolynomial):
 
     See Also
     --------
-    BaseMultivariatePolynomial:
+    BaseMultivariateQuadraticPolynomial:
         Abstract class for multivariate degree 2 polynomials.
-    IntegerPolynomial:
+    IntegerQuadraticPolynomial:
         Multivariate degree 2 polynomials over non-negative integers with a
         fixed number of bits.
-    SpinPolynomial:
+    SpinQuadraticPolynomial:
         Multivariate degree 2 polynomials over vectors whose entries are in
         {-1, 1}.
     models.QUBO: Implementation of the QUBO problem.

--- a/src/simulated_bifurcation/polynomial/binary_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/binary_polynomial.py
@@ -1,6 +1,11 @@
 """
 Implementation of multivariate degree 2 polynomials over binary vectors.
 
+.. deprecated:: 1.2.1
+    `BinaryPolynomial` will be modified in simulated-bifurcation 1.3.0, it
+    is replaced by `BinaryQuadraticPolynomial` in prevision of the addition
+    of multivariate polynomials of an arbitrary degree.
+
 Multivariate degree 2 polynomials are the sum of a quadratic form and a
 linear form plus a constant term:
 `ΣΣ Q(i,j)x(i)x(j) + Σ l(i)x(i) + c`
@@ -144,6 +149,15 @@ class BinaryQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
 
 
 class BinaryPolynomial(BinaryQuadraticPolynomial):
+
+    """
+    .. deprecated:: 1.2.1
+        `BinaryPolynomial` will be modified in simulated-bifurcation 1.3.0,
+        it is replaced by `BinaryQuadraticPolynomial` in prevision of the
+        addition of multivariate polynomials of an arbitrary degree.
+
+    """
+
     def __init__(self, *args, **kwargs) -> None:
         # 2023-10-03, 1.2.1
         warnings.warn(

--- a/src/simulated_bifurcation/polynomial/integer_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/integer_polynomial.py
@@ -15,12 +15,12 @@ that is integers between 0 and 127 inclusive).
 
 See Also
 --------
-BaseMultivariatePolynomial:
+BaseMultivariateQuadraticPolynomial:
     Abstract class for multivariate degree 2 polynomials.
-BinaryPolynomial:
+BinaryQuadraticPolynomial:
     Multivariate degree 2 polynomials over vectors whose entries are in
     {0, 1}.
-SpinPolynomial:
+SpinQuadraticPolynomial:
     Multivariate degree 2 polynomials over vectors whose entries are in
     {-1, 1}.
 models:
@@ -35,10 +35,10 @@ import numpy as np
 import torch
 
 from ..ising_core import IsingCore
-from .base_multivariate_polynomial import BaseMultivariatePolynomial
+from .base_multivariate_polynomial import BaseMultivariateQuadraticPolynomial
 
 
-class IntegerPolynomial(BaseMultivariatePolynomial):
+class IntegerQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
 
     """
     Multivariate degree 2 polynomials over fixed bit-width integer vectors.
@@ -94,12 +94,12 @@ class IntegerPolynomial(BaseMultivariatePolynomial):
 
     See Also
     --------
-    BinaryPolynomial:
+    BinaryQuadraticPolynomial:
         Multivariate degree 2 polynomials over vectors whose entries are in
         {0, 1}.
-    BaseMultivariatePolynomial:
+    BaseMultivariateQuadraticPolynomial:
         Abstract class for multivariate degree 2 polynomials.
-    SpinPolynomial:
+    SpinQuadraticPolynomial:
         Multivariate degree 2 polynomials over vectors whose entries are in
         {-1, 1}.
     models:

--- a/src/simulated_bifurcation/polynomial/integer_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/integer_polynomial.py
@@ -15,7 +15,7 @@ that is integers between 0 and 127 inclusive).
 
 See Also
 --------
-IsingPolynomialInterface:
+BaseMultivariatePolynomial:
     Abstract class for multivariate degree 2 polynomials.
 BinaryPolynomial:
     Multivariate degree 2 polynomials over vectors whose entries are in
@@ -35,10 +35,10 @@ import numpy as np
 import torch
 
 from ..ising_core import IsingCore
-from .ising_polynomial_interface import IsingPolynomialInterface
+from .base_multivariate_polynomial import BaseMultivariatePolynomial
 
 
-class IntegerPolynomial(IsingPolynomialInterface):
+class IntegerPolynomial(BaseMultivariatePolynomial):
 
     """
     Multivariate degree 2 polynomials over fixed bit-width integer vectors.
@@ -97,7 +97,7 @@ class IntegerPolynomial(IsingPolynomialInterface):
     BinaryPolynomial:
         Multivariate degree 2 polynomials over vectors whose entries are in
         {0, 1}.
-    IsingPolynomialInterface:
+    BaseMultivariatePolynomial:
         Abstract class for multivariate degree 2 polynomials.
     SpinPolynomial:
         Multivariate degree 2 polynomials over vectors whose entries are in

--- a/src/simulated_bifurcation/polynomial/integer_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/integer_polynomial.py
@@ -29,6 +29,7 @@ models:
 
 """
 
+import warnings
 from typing import Optional, Union
 
 import numpy as np
@@ -185,5 +186,12 @@ class IntegerQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
 
 class IntegerPolynomial(IntegerQuadraticPolynomial):
     def __init__(self, *args, **kwargs) -> None:
-        # TODO: deprecation warning
+        # 2023-10-03, 1.2.1
+        warnings.warn(
+            "`IntegerPolynomial` is deprecated as of simulated-bifurcation 1.2.1, and "
+            "its behaviour will change in simulated-bifurcation 1.3.0. Please use "
+            "`IntegerQuadraticPolynomial` instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
         super().__init__(*args, **kwargs)

--- a/src/simulated_bifurcation/polynomial/integer_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/integer_polynomial.py
@@ -181,3 +181,9 @@ class IntegerQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
         else:
             int_vars = None
         return int_vars
+
+
+class IntegerPolynomial(IntegerQuadraticPolynomial):
+    def __init__(self, *args, **kwargs) -> None:
+        # TODO: deprecation warning
+        super().__init__(*args, **kwargs)

--- a/src/simulated_bifurcation/polynomial/integer_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/integer_polynomial.py
@@ -1,6 +1,11 @@
 """
 Implementation of multivariate degree 2 polynomials over integer vectors.
 
+.. deprecated:: 1.2.1
+    `IntegerPolynomial` will be modified in simulated-bifurcation 1.3.0, it
+    is replaced by `IntegerQuadraticPolynomial` in prevision of the
+    addition of multivariate polynomials of an arbitrary degree.
+
 Multivariate degree 2 polynomials are the sum of a quadratic form and a
 linear form plus a constant term:
 `ΣΣ Q(i,j)x(i)x(j) + Σ l(i)x(i) + c`
@@ -185,6 +190,16 @@ class IntegerQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
 
 
 class IntegerPolynomial(IntegerQuadraticPolynomial):
+
+    """
+    .. deprecated:: 1.2.1
+        `IntegerPolynomial` will be modified in simulated-bifurcation
+        1.3.0, it is replaced by `IntegerQuadraticPolynomial` in
+        prevision of the addition of multivariate polynomials of an
+        arbitrary degree.
+
+    """
+
     def __init__(self, *args, **kwargs) -> None:
         # 2023-10-03, 1.2.1
         warnings.warn(

--- a/src/simulated_bifurcation/polynomial/spin_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/spin_polynomial.py
@@ -13,12 +13,12 @@ solved with the Simulated Bifurcation algorithm.
 
 See Also
 --------
-BinaryPolynomial:
+BinaryQuadraticPolynomial:
     Multivariate degree 2 polynomials over vectors whose entries are in
     {0, 1}.
-BaseMultivariatePolynomial:
+BaseMultivariateQuadraticPolynomial:
     Abstract class for multivariate degree 2 polynomials.
-IntegerPolynomial:
+IntegerQuadraticPolynomial:
     Multivariate degree 2 polynomials over non-negative integers with a
     fixed number of bits.
 models.Ising: Implementation of the Ising problem.
@@ -42,10 +42,10 @@ import numpy as np
 import torch
 
 from ..ising_core import IsingCore
-from .base_multivariate_polynomial import BaseMultivariatePolynomial
+from .base_multivariate_polynomial import BaseMultivariateQuadraticPolynomial
 
 
-class SpinPolynomial(BaseMultivariatePolynomial):
+class SpinQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
 
     """
     Multivariate degree 2 polynomials over spin vectors.
@@ -93,12 +93,12 @@ class SpinPolynomial(BaseMultivariatePolynomial):
 
     See Also
     --------
-    BinaryPolynomial:
+    BinaryQuadraticPolynomial:
         Multivariate degree 2 polynomials over vectors whose entries are in
         {0, 1}.
-    BaseMultivariatePolynomial:
+    BaseMultivariateQuadraticPolynomial:
         Abstract class for multivariate degree 2 polynomials.
-    IntegerPolynomial:
+    IntegerQuadraticPolynomial:
         Multivariate degree 2 polynomials over non-negative integers with a
         fixed number of bits.
     models.Ising: Implementation of the Ising problem.

--- a/src/simulated_bifurcation/polynomial/spin_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/spin_polynomial.py
@@ -1,6 +1,11 @@
 """
 Implementation of multivariate degree 2 polynomials over spin vectors.
 
+.. deprecated:: 1.2.1
+    `SpinPolynomial` will be modified in simulated-bifurcation 1.3.0, it is
+    replaced by `SpinQuadraticPolynomial` in prevision of the addition of
+    multivariate polynomials of an arbitrary degree.
+
 Multivariate degree 2 polynomials are the sum of a quadratic form and a
 linear form plus a constant term:
 `ΣΣ Q(i,j)x(i)x(j) + Σ l(i)x(i) + c`
@@ -150,6 +155,15 @@ class SpinQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
 
 
 class SpinPolynomial(SpinQuadraticPolynomial):
+
+    """
+    .. deprecated:: 1.2.1
+        `SpinPolynomial` will be modified in simulated-bifurcation 1.3.0,
+        it is replaced by `SpinQuadraticPolynomial` in prevision of the
+        addition of multivariate polynomials of an arbitrary degree.
+
+    """
+
     def __init__(self, *args, **kwargs) -> None:
         # 2023-10-03, 1.2.1
         warnings.warn(

--- a/src/simulated_bifurcation/polynomial/spin_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/spin_polynomial.py
@@ -16,7 +16,7 @@ See Also
 BinaryPolynomial:
     Multivariate degree 2 polynomials over vectors whose entries are in
     {0, 1}.
-IsingPolynomialInterface:
+BaseMultivariatePolynomial:
     Abstract class for multivariate degree 2 polynomials.
 IntegerPolynomial:
     Multivariate degree 2 polynomials over non-negative integers with a
@@ -42,10 +42,10 @@ import numpy as np
 import torch
 
 from ..ising_core import IsingCore
-from .ising_polynomial_interface import IsingPolynomialInterface
+from .base_multivariate_polynomial import BaseMultivariatePolynomial
 
 
-class SpinPolynomial(IsingPolynomialInterface):
+class SpinPolynomial(BaseMultivariatePolynomial):
 
     """
     Multivariate degree 2 polynomials over spin vectors.
@@ -96,7 +96,7 @@ class SpinPolynomial(IsingPolynomialInterface):
     BinaryPolynomial:
         Multivariate degree 2 polynomials over vectors whose entries are in
         {0, 1}.
-    IsingPolynomialInterface:
+    BaseMultivariatePolynomial:
         Abstract class for multivariate degree 2 polynomials.
     IntegerPolynomial:
         Multivariate degree 2 polynomials over non-negative integers with a

--- a/src/simulated_bifurcation/polynomial/spin_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/spin_polynomial.py
@@ -146,3 +146,9 @@ class SpinQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
 
         """
         return ising.computed_spins
+
+
+class SpinPolynomial(SpinQuadraticPolynomial):
+    def __init__(self, *args, **kwargs) -> None:
+        # TODO: deprecation warning
+        super().__init__(*args, **kwargs)

--- a/src/simulated_bifurcation/polynomial/spin_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/spin_polynomial.py
@@ -36,6 +36,7 @@ IsingCore class:
 
 """
 
+import warnings
 from typing import Union
 
 import numpy as np
@@ -150,5 +151,12 @@ class SpinQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
 
 class SpinPolynomial(SpinQuadraticPolynomial):
     def __init__(self, *args, **kwargs) -> None:
-        # TODO: deprecation warning
+        # 2023-10-03, 1.2.1
+        warnings.warn(
+            "`SpinPolynomial` is deprecated as of simulated-bifurcation 1.2.1, and "
+            "its behaviour will change in simulated-bifurcation 1.3.0. Please use "
+            "`SpinQuadraticPolynomial` instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
         super().__init__(*args, **kwargs)

--- a/src/simulated_bifurcation/simulated_bifurcation.py
+++ b/src/simulated_bifurcation/simulated_bifurcation.py
@@ -29,9 +29,9 @@ import torch
 from numpy import ndarray
 
 from .polynomial import (
+    BaseMultivariatePolynomial,
     BinaryPolynomial,
     IntegerPolynomial,
-    IsingPolynomialInterface,
     SpinPolynomial,
 )
 
@@ -813,7 +813,7 @@ def build_model(
     input_type: str = "spin",
     dtype: torch.dtype = torch.float32,
     device: Union[str, torch.device] = "cpu",
-) -> IsingPolynomialInterface:
+) -> BaseMultivariatePolynomial:
     """
     Instantiate a multivariate degree 2 polynomial over a given domain.
 
@@ -879,7 +879,7 @@ def build_model(
         Shorthands for polynomial creation and optimization.
     polynomial :
         Module providing some polynomial types as well as an abstract
-        polynomial class `IsingPolynomialInterface`.
+        polynomial class `BaseMultivariatePolynomial`.
     models :
         Module containing the implementation of several common
         combinatorial optimization problems.

--- a/src/simulated_bifurcation/simulated_bifurcation.py
+++ b/src/simulated_bifurcation/simulated_bifurcation.py
@@ -29,10 +29,10 @@ import torch
 from numpy import ndarray
 
 from .polynomial import (
-    BaseMultivariatePolynomial,
-    BinaryPolynomial,
-    IntegerPolynomial,
-    SpinPolynomial,
+    BaseMultivariateQuadraticPolynomial,
+    BinaryQuadraticPolynomial,
+    IntegerQuadraticPolynomial,
+    SpinQuadraticPolynomial,
 )
 
 
@@ -813,7 +813,7 @@ def build_model(
     input_type: str = "spin",
     dtype: torch.dtype = torch.float32,
     device: Union[str, torch.device] = "cpu",
-) -> BaseMultivariatePolynomial:
+) -> BaseMultivariateQuadraticPolynomial:
     """
     Instantiate a multivariate degree 2 polynomial over a given domain.
 
@@ -852,12 +852,12 @@ def build_model(
 
     Returns
     -------
-    SpinPolynomial | BinaryPolynomial | IntegerPolynomial
+    SpinQuadraticPolynomial | BinaryQuadraticPolynomial | IntegerQuadraticPolynomial
         The polynomial described by `matrix`, `vector` and `constant` on
         the domain specified by `input_type`.
-        - `input_type="spin"` : SpinPolynomial.
-        - `input_type="binary"` : BinaryPolynomial.
-        - `input_type="int..."` : IntegerPolynomial.
+        - `input_type="spin"` : SpinQuadraticPolynomial.
+        - `input_type="binary"` : BinaryQuadraticPolynomial.
+        - `input_type="int..."` : IntegerQuadraticPolynomial.
 
     Raises
     ------
@@ -879,7 +879,7 @@ def build_model(
         Shorthands for polynomial creation and optimization.
     polynomial :
         Module providing some polynomial types as well as an abstract
-        polynomial class `BaseMultivariatePolynomial`.
+        polynomial class `BaseMultivariateQuadraticPolynomial`.
     models :
         Module containing the implementation of several common
         combinatorial optimization problems.
@@ -944,11 +944,11 @@ def build_model(
     int_type_pattern = re.compile(int_type_regex)
 
     if input_type == "spin":
-        return SpinPolynomial(
+        return SpinQuadraticPolynomial(
             matrix=matrix, vector=vector, constant=constant, dtype=dtype, device=device
         )
     if input_type == "binary":
-        return BinaryPolynomial(
+        return BinaryQuadraticPolynomial(
             matrix=matrix, vector=vector, constant=constant, dtype=dtype, device=device
         )
     if int_type_pattern.match(input_type) is None:
@@ -960,7 +960,7 @@ def build_model(
             f'Examples: "int7", "int42", ...'
         )
     number_of_bits = int(input_type[3:])
-    return IntegerPolynomial(
+    return IntegerQuadraticPolynomial(
         matrix=matrix,
         vector=vector,
         constant=constant,

--- a/tests/test_binary_polynomial.py
+++ b/tests/test_binary_polynomial.py
@@ -1,7 +1,10 @@
 import pytest
 import torch
 
-from src.simulated_bifurcation.polynomial import BinaryQuadraticPolynomial
+from src.simulated_bifurcation.polynomial import (
+    BinaryPolynomial,
+    BinaryQuadraticPolynomial,
+)
 
 matrix = torch.tensor(
     [
@@ -64,3 +67,8 @@ def test_optimize_binary_polynomial():
     binary_vars, value = binary_polynomial.optimize(verbose=False)
     assert torch.equal(binary_vars, torch.tensor([1, 0, 1], dtype=torch.float32))
     assert value == -3.0
+
+
+def test_deprecation_warning():
+    with pytest.warns(DeprecationWarning):
+        BinaryPolynomial(matrix, vector, constant)

--- a/tests/test_binary_polynomial.py
+++ b/tests/test_binary_polynomial.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from src.simulated_bifurcation.polynomial import BinaryPolynomial
+from src.simulated_bifurcation.polynomial import BinaryQuadraticPolynomial
 
 matrix = torch.tensor(
     [
@@ -16,7 +16,7 @@ constant = 1
 
 
 def test_init_binary_polynomial():
-    binary_polynomial = BinaryPolynomial(matrix, vector, constant)
+    binary_polynomial = BinaryQuadraticPolynomial(matrix, vector, constant)
     ising = binary_polynomial.to_ising()
     assert binary_polynomial.convert_spins(ising) is None
     ising.computed_spins = torch.tensor(
@@ -53,14 +53,14 @@ def test_init_binary_polynomial():
 
 
 def test_call_binary_polynomial():
-    binary_polynomial = BinaryPolynomial(matrix, vector, constant)
+    binary_polynomial = BinaryQuadraticPolynomial(matrix, vector, constant)
     assert binary_polynomial(torch.tensor([1, 0, 1], dtype=torch.float32)) == -3
     with pytest.raises(ValueError):
         binary_polynomial(torch.tensor([1, 2, 3], dtype=torch.float32))
 
 
 def test_optimize_binary_polynomial():
-    binary_polynomial = BinaryPolynomial(matrix, vector, constant)
+    binary_polynomial = BinaryQuadraticPolynomial(matrix, vector, constant)
     binary_vars, value = binary_polynomial.optimize(verbose=False)
     assert torch.equal(binary_vars, torch.tensor([1, 0, 1], dtype=torch.float32))
     assert value == -3.0

--- a/tests/test_integer_polynomial.py
+++ b/tests/test_integer_polynomial.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from src.simulated_bifurcation.polynomial import IntegerPolynomial
+from src.simulated_bifurcation.polynomial import IntegerQuadraticPolynomial
 
 matrix = torch.tensor(
     [
@@ -17,11 +17,11 @@ constant = 1
 
 def test_init_integer_polynomial():
     with pytest.raises(ValueError):
-        IntegerPolynomial(matrix, vector, constant, 0)
+        IntegerQuadraticPolynomial(matrix, vector, constant, 0)
     with pytest.raises(ValueError):
         # noinspection PyTypeChecker
-        IntegerPolynomial(matrix, vector, constant, 2.5)
-    integer_polynomial = IntegerPolynomial(matrix, vector, constant, 2)
+        IntegerQuadraticPolynomial(matrix, vector, constant, 2.5)
+    integer_polynomial = IntegerQuadraticPolynomial(matrix, vector, constant, 2)
     ising = integer_polynomial.to_ising()
     assert integer_polynomial.convert_spins(ising) is None
     ising.computed_spins = torch.tensor(
@@ -66,14 +66,14 @@ def test_init_integer_polynomial():
 
 
 def test_call_integer_polynomial():
-    integer_polynomial = IntegerPolynomial(matrix, vector, constant, 2)
+    integer_polynomial = IntegerQuadraticPolynomial(matrix, vector, constant, 2)
     assert integer_polynomial(torch.tensor([2, 3, 0], dtype=torch.float32)) == 21
     with pytest.raises(ValueError):
         integer_polynomial(torch.tensor([1, 2, 8], dtype=torch.float32))
 
 
 def test_optimize_integer_polynomial():
-    integer_polynomial = IntegerPolynomial(matrix, vector, constant, 2)
+    integer_polynomial = IntegerQuadraticPolynomial(matrix, vector, constant, 2)
     int_vars, value = integer_polynomial.optimize(verbose=False)
     assert torch.equal(int_vars, torch.tensor([3, 0, 3], dtype=torch.float32))
     assert value == -23.0

--- a/tests/test_integer_polynomial.py
+++ b/tests/test_integer_polynomial.py
@@ -1,7 +1,10 @@
 import pytest
 import torch
 
-from src.simulated_bifurcation.polynomial import IntegerQuadraticPolynomial
+from src.simulated_bifurcation.polynomial import (
+    IntegerPolynomial,
+    IntegerQuadraticPolynomial,
+)
 
 matrix = torch.tensor(
     [
@@ -77,3 +80,8 @@ def test_optimize_integer_polynomial():
     int_vars, value = integer_polynomial.optimize(verbose=False)
     assert torch.equal(int_vars, torch.tensor([3, 0, 3], dtype=torch.float32))
     assert value == -23.0
+
+
+def test_deprecation_warning():
+    with pytest.warns(DeprecationWarning):
+        IntegerPolynomial(matrix, vector, constant)

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -3,7 +3,7 @@ import torch
 
 from src.simulated_bifurcation import build_model
 from src.simulated_bifurcation.ising_core import IsingCore
-from src.simulated_bifurcation.polynomial import BaseMultivariatePolynomial
+from src.simulated_bifurcation.polynomial import BaseMultivariateQuadraticPolynomial
 
 matrix = torch.tensor(
     [
@@ -17,7 +17,7 @@ vector = torch.tensor([[1], [2], [3]], dtype=torch.float32)
 constant = 1
 
 
-class BaseMultivariatePolynomialImpl(BaseMultivariatePolynomial):
+class BaseMultivariateQuadraticPolynomialImpl(BaseMultivariateQuadraticPolynomial):
     def to_ising(self):
         pass  # pragma: no cover
 
@@ -26,7 +26,7 @@ class BaseMultivariatePolynomialImpl(BaseMultivariatePolynomial):
 
 
 def test_init_polynomial_from_tensors():
-    polynomial = BaseMultivariatePolynomialImpl(matrix, vector, constant)
+    polynomial = BaseMultivariateQuadraticPolynomialImpl(matrix, vector, constant)
     assert torch.equal(polynomial.matrix, matrix)
     assert torch.equal(polynomial.vector, vector.reshape(3))
     assert polynomial.constant == 1.0
@@ -43,7 +43,7 @@ def test_init_polynomial_from_tensors():
 
 
 def test_init_polynomial_from_arrays():
-    polynomial = BaseMultivariatePolynomialImpl(
+    polynomial = BaseMultivariateQuadraticPolynomialImpl(
         matrix.numpy(), vector.numpy(), constant
     )
     assert torch.equal(polynomial.matrix, matrix)
@@ -57,7 +57,7 @@ def test_init_polynomial_from_arrays():
 
 
 def test_init_polynomial_without_order_one_and_zero():
-    polynomial = BaseMultivariatePolynomialImpl(matrix)
+    polynomial = BaseMultivariateQuadraticPolynomialImpl(matrix)
     assert torch.equal(polynomial.matrix, matrix)
     assert torch.equal(polynomial.vector, torch.zeros(polynomial.dimension))
     assert polynomial.constant == 0.0
@@ -71,11 +71,11 @@ def test_init_polynomial_without_order_one_and_zero():
 def test_init_with_wrong_parameters():
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker
-        BaseMultivariatePolynomialImpl(None)
+        BaseMultivariateQuadraticPolynomialImpl(None)
     with pytest.raises(ValueError):
-        BaseMultivariatePolynomialImpl(torch.unsqueeze(matrix, 0))
+        BaseMultivariateQuadraticPolynomialImpl(torch.unsqueeze(matrix, 0))
     with pytest.raises(ValueError):
-        BaseMultivariatePolynomialImpl(
+        BaseMultivariateQuadraticPolynomialImpl(
             torch.tensor(
                 [
                     [1, 2, 3],
@@ -86,29 +86,29 @@ def test_init_with_wrong_parameters():
         )
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker
-        BaseMultivariatePolynomialImpl(matrix, ("hello", "world!"))
+        BaseMultivariateQuadraticPolynomialImpl(matrix, ("hello", "world!"))
     with pytest.raises(ValueError):
         # noinspection PyTypeChecker
-        BaseMultivariatePolynomialImpl(matrix, 1)
+        BaseMultivariateQuadraticPolynomialImpl(matrix, 1)
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker
-        BaseMultivariatePolynomialImpl(matrix, constant="hello world!")
+        BaseMultivariateQuadraticPolynomialImpl(matrix, constant="hello world!")
 
 
 def test_check_device():
-    BaseMultivariatePolynomialImpl(matrix, device="cpu")
+    BaseMultivariateQuadraticPolynomialImpl(matrix, device="cpu")
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker
-        BaseMultivariatePolynomialImpl(matrix, device=1)
+        BaseMultivariateQuadraticPolynomialImpl(matrix, device=1)
     if not torch.cuda.is_available():  # pragma: no cover
         with pytest.raises(RuntimeError):
-            BaseMultivariatePolynomialImpl(matrix, device="cuda")
+            BaseMultivariateQuadraticPolynomialImpl(matrix, device="cuda")
     else:  # pragma: no cover
-        BaseMultivariatePolynomialImpl(matrix, device="cuda")
+        BaseMultivariateQuadraticPolynomialImpl(matrix, device="cuda")
 
 
 def test_call_polynomial():
-    polynomial = BaseMultivariatePolynomialImpl(matrix)
+    polynomial = BaseMultivariateQuadraticPolynomialImpl(matrix)
     assert polynomial(torch.tensor([0, 0, 0], dtype=torch.float32)) == 0.0
     assert torch.equal(
         polynomial(
@@ -136,7 +136,7 @@ def test_call_polynomial():
 
 
 def test_call_polynomial_with_accepted_values():
-    polynomial = BaseMultivariatePolynomialImpl(matrix, accepted_values=[0, 1])
+    polynomial = BaseMultivariateQuadraticPolynomialImpl(matrix, accepted_values=[0, 1])
     assert polynomial(torch.tensor([0, 0, 0], dtype=torch.float32)) == 0
     with pytest.raises(ValueError):
         polynomial(torch.tensor([0, 1, 2], dtype=torch.float32))
@@ -151,10 +151,10 @@ def test_call_polynomial_with_accepted_values():
 def test_ising_interface():
     with pytest.raises(NotImplementedError):
         # noinspection PyTypeChecker
-        BaseMultivariatePolynomial.to_ising(None)
+        BaseMultivariateQuadraticPolynomial.to_ising(None)
     with pytest.raises(NotImplementedError):
         # noinspection PyTypeChecker
-        BaseMultivariatePolynomial.convert_spins(None, None)
+        BaseMultivariateQuadraticPolynomial.convert_spins(None, None)
 
 
 def test_best_only():

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -3,7 +3,10 @@ import torch
 
 from src.simulated_bifurcation import build_model
 from src.simulated_bifurcation.ising_core import IsingCore
-from src.simulated_bifurcation.polynomial import BaseMultivariateQuadraticPolynomial
+from src.simulated_bifurcation.polynomial import (
+    BaseMultivariateQuadraticPolynomial,
+    IsingPolynomialInterface,
+)
 
 matrix = torch.tensor(
     [
@@ -18,6 +21,14 @@ constant = 1
 
 
 class BaseMultivariateQuadraticPolynomialImpl(BaseMultivariateQuadraticPolynomial):
+    def to_ising(self):
+        pass  # pragma: no cover
+
+    def convert_spins(self, ising: IsingCore):
+        pass  # pragma: no cover
+
+
+class IsingPolynomialInterfaceImpl(IsingPolynomialInterface):
     def to_ising(self):
         pass  # pragma: no cover
 
@@ -212,3 +223,8 @@ def test_maximize():
         best_combination, torch.tensor([1.0, 1.0, 1.0], dtype=torch.float32)
     )
     assert 52.0 == best_value
+
+
+def test_deprecation_warning():
+    with pytest.warns(DeprecationWarning):
+        IsingPolynomialInterfaceImpl(matrix, accepted_values=[0, 1])

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -3,7 +3,7 @@ import torch
 
 from src.simulated_bifurcation import build_model
 from src.simulated_bifurcation.ising_core import IsingCore
-from src.simulated_bifurcation.polynomial import IsingPolynomialInterface
+from src.simulated_bifurcation.polynomial import BaseMultivariatePolynomial
 
 matrix = torch.tensor(
     [
@@ -17,7 +17,7 @@ vector = torch.tensor([[1], [2], [3]], dtype=torch.float32)
 constant = 1
 
 
-class IsingPolynomialInterfaceImpl(IsingPolynomialInterface):
+class BaseMultivariatePolynomialImpl(BaseMultivariatePolynomial):
     def to_ising(self):
         pass  # pragma: no cover
 
@@ -26,7 +26,7 @@ class IsingPolynomialInterfaceImpl(IsingPolynomialInterface):
 
 
 def test_init_polynomial_from_tensors():
-    polynomial = IsingPolynomialInterfaceImpl(matrix, vector, constant)
+    polynomial = BaseMultivariatePolynomialImpl(matrix, vector, constant)
     assert torch.equal(polynomial.matrix, matrix)
     assert torch.equal(polynomial.vector, vector.reshape(3))
     assert polynomial.constant == 1.0
@@ -43,7 +43,9 @@ def test_init_polynomial_from_tensors():
 
 
 def test_init_polynomial_from_arrays():
-    polynomial = IsingPolynomialInterfaceImpl(matrix.numpy(), vector.numpy(), constant)
+    polynomial = BaseMultivariatePolynomialImpl(
+        matrix.numpy(), vector.numpy(), constant
+    )
     assert torch.equal(polynomial.matrix, matrix)
     assert torch.equal(polynomial.vector, vector.reshape(3))
     assert polynomial.constant == 1.0
@@ -55,7 +57,7 @@ def test_init_polynomial_from_arrays():
 
 
 def test_init_polynomial_without_order_one_and_zero():
-    polynomial = IsingPolynomialInterfaceImpl(matrix)
+    polynomial = BaseMultivariatePolynomialImpl(matrix)
     assert torch.equal(polynomial.matrix, matrix)
     assert torch.equal(polynomial.vector, torch.zeros(polynomial.dimension))
     assert polynomial.constant == 0.0
@@ -69,11 +71,11 @@ def test_init_polynomial_without_order_one_and_zero():
 def test_init_with_wrong_parameters():
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker
-        IsingPolynomialInterfaceImpl(None)
+        BaseMultivariatePolynomialImpl(None)
     with pytest.raises(ValueError):
-        IsingPolynomialInterfaceImpl(torch.unsqueeze(matrix, 0))
+        BaseMultivariatePolynomialImpl(torch.unsqueeze(matrix, 0))
     with pytest.raises(ValueError):
-        IsingPolynomialInterfaceImpl(
+        BaseMultivariatePolynomialImpl(
             torch.tensor(
                 [
                     [1, 2, 3],
@@ -84,29 +86,29 @@ def test_init_with_wrong_parameters():
         )
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker
-        IsingPolynomialInterfaceImpl(matrix, ("hello", "world!"))
+        BaseMultivariatePolynomialImpl(matrix, ("hello", "world!"))
     with pytest.raises(ValueError):
         # noinspection PyTypeChecker
-        IsingPolynomialInterfaceImpl(matrix, 1)
+        BaseMultivariatePolynomialImpl(matrix, 1)
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker
-        IsingPolynomialInterfaceImpl(matrix, constant="hello world!")
+        BaseMultivariatePolynomialImpl(matrix, constant="hello world!")
 
 
 def test_check_device():
-    IsingPolynomialInterfaceImpl(matrix, device="cpu")
+    BaseMultivariatePolynomialImpl(matrix, device="cpu")
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker
-        IsingPolynomialInterfaceImpl(matrix, device=1)
+        BaseMultivariatePolynomialImpl(matrix, device=1)
     if not torch.cuda.is_available():  # pragma: no cover
         with pytest.raises(RuntimeError):
-            IsingPolynomialInterfaceImpl(matrix, device="cuda")
+            BaseMultivariatePolynomialImpl(matrix, device="cuda")
     else:  # pragma: no cover
-        IsingPolynomialInterfaceImpl(matrix, device="cuda")
+        BaseMultivariatePolynomialImpl(matrix, device="cuda")
 
 
 def test_call_polynomial():
-    polynomial = IsingPolynomialInterfaceImpl(matrix)
+    polynomial = BaseMultivariatePolynomialImpl(matrix)
     assert polynomial(torch.tensor([0, 0, 0], dtype=torch.float32)) == 0.0
     assert torch.equal(
         polynomial(
@@ -134,7 +136,7 @@ def test_call_polynomial():
 
 
 def test_call_polynomial_with_accepted_values():
-    polynomial = IsingPolynomialInterfaceImpl(matrix, accepted_values=[0, 1])
+    polynomial = BaseMultivariatePolynomialImpl(matrix, accepted_values=[0, 1])
     assert polynomial(torch.tensor([0, 0, 0], dtype=torch.float32)) == 0
     with pytest.raises(ValueError):
         polynomial(torch.tensor([0, 1, 2], dtype=torch.float32))
@@ -149,10 +151,10 @@ def test_call_polynomial_with_accepted_values():
 def test_ising_interface():
     with pytest.raises(NotImplementedError):
         # noinspection PyTypeChecker
-        IsingPolynomialInterface.to_ising(None)
+        BaseMultivariatePolynomial.to_ising(None)
     with pytest.raises(NotImplementedError):
         # noinspection PyTypeChecker
-        IsingPolynomialInterface.convert_spins(None, None)
+        BaseMultivariatePolynomial.convert_spins(None, None)
 
 
 def test_best_only():

--- a/tests/test_spin_polynomial.py
+++ b/tests/test_spin_polynomial.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from src.simulated_bifurcation.polynomial import SpinPolynomial
+from src.simulated_bifurcation.polynomial import SpinQuadraticPolynomial
 
 matrix = torch.tensor(
     [
@@ -16,7 +16,7 @@ constant = 1
 
 
 def test_init_spin_polynomial():
-    spin_polynomial = SpinPolynomial(matrix, vector, constant)
+    spin_polynomial = SpinQuadraticPolynomial(matrix, vector, constant)
     ising = spin_polynomial.to_ising()
     ising.computed_spins = torch.tensor(
         [
@@ -52,21 +52,21 @@ def test_init_spin_polynomial():
 
 
 def test_call_spin_polynomial():
-    spin_polynomial = SpinPolynomial(matrix, vector, constant)
+    spin_polynomial = SpinQuadraticPolynomial(matrix, vector, constant)
     assert spin_polynomial(torch.tensor([1, -1, 1], dtype=torch.float32)) == -11
     with pytest.raises(ValueError):
         spin_polynomial(torch.tensor([1, 2, 3], dtype=torch.float32))
 
 
 def test_optimize_spin_polynomial():
-    spin_polynomial = SpinPolynomial(matrix, vector, constant)
+    spin_polynomial = SpinQuadraticPolynomial(matrix, vector, constant)
     spin_vars, value = spin_polynomial.optimize(verbose=False)
     assert torch.equal(spin_vars, torch.tensor([1, -1, 1], dtype=torch.float32))
     assert value == -11.0
 
 
 def test_to():
-    spin_polynomial = SpinPolynomial(matrix, vector, constant)
+    spin_polynomial = SpinQuadraticPolynomial(matrix, vector, constant)
 
     def check_device_and_dtype(dtype: torch.dtype):
         assert spin_polynomial.dtype == dtype

--- a/tests/test_spin_polynomial.py
+++ b/tests/test_spin_polynomial.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from src.simulated_bifurcation.polynomial import SpinQuadraticPolynomial
+from src.simulated_bifurcation.polynomial import SpinPolynomial, SpinQuadraticPolynomial
 
 matrix = torch.tensor(
     [
@@ -91,3 +91,8 @@ def test_to():
 
     spin_polynomial.to()
     check_device_and_dtype(torch.float64)
+
+
+def test_deprecation_warning():
+    with pytest.warns(DeprecationWarning):
+        SpinPolynomial(matrix, vector, constant)


### PR DESCRIPTION
# 💬 Pull Request Description

Deprecation of `IsingPolynomialInterface`, `BinaryPolynomial`, `IntegerPolynomial` and `SpinPolynomial` in prevision of the addition of multivariate polynomials of an arbitrary degree. Their behaviour will be modified in simulated-bifurcation 1.3.0.

They are respectively replaced by `BaseMultivariateQuadraticPolynomial`, `BinaryQuadraticPolynomial`, `IntegerQuadraticPolynomial` and `SpinQuadraticPolynomial`.

# ✔️ Check list

_Before you open the pull request, make sure the following requirements are met._

- [x] The code matches the styling rules
- [x] The new code is covered by relevant tests
- [x] Documentation was added

# 🚀 New features

- `class BaseMultivariateQuadraticPolynomial`
- `class BinaryQuadraticPolynomial`
- `class IntegerQuadraticPolynomial`
- `class SpinQuadraticPolynomial`

# 🐞 Bug fixes

None

# 📣 Supplementary information

The deprecated classes will be modified to implement the SB algorithm over multivariate polynomials of an arbitrary degree. See https://arxiv.org/abs/2211.09296.