### PR TITLE
adapt best_only return when maximizing

### DIFF
--- a/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
@@ -404,9 +404,9 @@ class BaseMultivariateQuadraticPolynomial(ABC):
         result = self.sb_result.t()
         evaluation = self(result)
         if best_only:
-            i_min = torch.argmin(evaluation)
-            result = result[i_min]
-            evaluation = evaluation[i_min]
+            i_best = torch.argmin(evaluation) if minimize else torch.argmax(evaluation)
+            result = result[i_best]
+            evaluation = evaluation[i_best]
         return result, evaluation
 
     @final

--- a/tests/models/test_qubo.py
+++ b/tests/models/test_qubo.py
@@ -13,3 +13,21 @@ def test_qubo():
     binary_vector, value = model.maximize(agents=10, verbose=False, best_only=True)
     assert torch.equal(torch.tensor([1.0, 0.0, 1.0]), binary_vector)
     assert 6.0 == value
+
+
+def test_lp_problem_formulated_as_qubo():
+    torch.manual_seed(42)
+    P = 15.5
+    Q = torch.tensor(
+        [
+            [2, -P, -P, 0, 0, 0],
+            [0, 2, -P, -P, 0, 0],
+            [0, 0, 2, -2 * P, 0, 0],
+            [0, 0, 0, 2, -P, 0],
+            [0, 0, 0, 0, 4.5, -P],
+            [0, 0, 0, 0, 0, 3],
+        ]
+    )
+    binary_vector, objective_value = QUBO(Q).maximize(agents=10, verbose=False)
+    assert torch.equal(torch.tensor([1.0, 0.0, 0.0, 1.0, 0.0, 1.0]), binary_vector)
+    assert 7.0 == objective_value


### PR DESCRIPTION
# 💬 Pull Request Description

Following #27, an inspection of the code has been pursued. The problem originated from the fact that in _best-only_ mode, the best objective value return was always retrieved from an _argmin_ function, even if a maximization was carried out. This behavior was fixed by replacing the _argmin_ by an _argmax_ when maximizing.

# ✔️ Check list

_Before you open the pull request, make sure the following requirements are met._

- [x] The code matches the styling rules
- [x] The new code is covered by relevant tests
- [x] Documentation was added

# 🚀 New features

No new feature was added.

# 🐞 Bug fixes

The highest objective value is returned in _best-only_ mode when maximizing (previously, it was still the lowest value).

> The bug mentioned in #27 has been added to the tests pool in the `tests/` folder.

# 📣 Supplementary information

The bug that this PR fixes explains the curious pie charts from #27 since as the number of agents increased, the probability of finding a _bad value_ increased as well. As the worst value was returned instead of the best one, the _bad values_ were over represented in the algorithm's outputs. Hence the drop in performance when the number of agents was more important.