### PR TITLE
Energy-wise stop window

### DIFF
--- a/src/simulated_bifurcation/optimizer/simulated_bifurcation_optimizer.py
+++ b/src/simulated_bifurcation/optimizer/simulated_bifurcation_optimizer.py
@@ -121,7 +121,7 @@ class SimulatedBifurcationOptimizer:
 
     def __init_window(self, matrix: torch.Tensor, use_window: bool) -> None:
         self.window = StopWindow(
-            matrix.shape[0],
+            matrix,
             self.agents,
             self.convergence_threshold,
             matrix.dtype,

--- a/src/simulated_bifurcation/optimizer/stop_window.py
+++ b/src/simulated_bifurcation/optimizer/stop_window.py
@@ -14,20 +14,21 @@ class StopWindow:
 
     def __init__(
         self,
-        n_spins: int,
+        ising_tensor: torch.Tensor,
         n_agents: int,
         convergence_threshold: int,
         dtype: torch.dtype,
         device: Union[str, torch.device],
         verbose: bool,
     ) -> None:
-        self.n_spins = n_spins
+        self.ising_tensor = ising_tensor
+        self.n_spins = self.ising_tensor.shape[0]
         self.n_agents = n_agents
         self.__init_convergence_threshold(convergence_threshold)
         self.dtype = dtype
         self.device = device
         self.__init_tensors()
-        self.current_spins = self.__init_spins()
+        self.__init_energies()
         self.final_spins = self.__init_spins()
         self.progress = self.__init_progress_bar(verbose)
 
@@ -65,12 +66,15 @@ class StopWindow:
     def __init_tensor(self, dtype: torch.dtype) -> torch.Tensor:
         return torch.zeros(self.n_agents, device=self.device, dtype=dtype)
 
+    def __init_energies(self) -> None:
+        self.energies = torch.tensor([float("inf") for _ in range(self.n_agents)])
+
     def __init_tensors(self) -> None:
         self.stability = self.__init_tensor(torch.int16)
         self.newly_bifurcated = self.__init_tensor(torch.bool)
         self.previously_bifurcated = self.__init_tensor(torch.bool)
         self.bifurcated = self.__init_tensor(torch.bool)
-        self.equal = self.__init_tensor(torch.bool)
+        self.stable_agents = self.__init_tensor(torch.bool)
 
     def __init_spins(self) -> torch.Tensor:
         return torch.zeros(size=self.shape, dtype=self.dtype, device=self.device)
@@ -92,38 +96,38 @@ class StopWindow:
         torch.eq(self.stability, self.convergence_threshold - 1, out=self.bifurcated)
 
     def __update_stability_streak(self) -> None:
-        self.stability[torch.logical_and(self.equal, self.not_bifurcated)] += 1
-        self.stability[torch.logical_and(self.not_equal, self.not_bifurcated)] = 0
+        self.stability[torch.logical_and(self.stable_agents, self.not_bifurcated)] += 1
+        self.stability[torch.logical_and(self.changed_agents, self.not_bifurcated)] = 0
 
     @property
-    def not_equal(self) -> torch.Tensor:
-        return torch.logical_not(self.equal)
+    def changed_agents(self) -> torch.Tensor:
+        return torch.logical_not(self.stable_agents)
 
     @property
     def not_bifurcated(self) -> torch.Tensor:
         return torch.logical_not(self.bifurcated)
 
-    def __compare_spins(self, sampled_spins: torch.Tensor) -> None:
+    def __compare_energies(self, sampled_spins: torch.Tensor) -> None:
+        energies = torch.nn.functional.bilinear(
+            sampled_spins.t(), sampled_spins.t(), torch.unsqueeze(self.ising_tensor, 0)
+        ).reshape(self.n_agents)
         torch.eq(
-            torch.einsum("ik, ik -> k", self.current_spins, sampled_spins),
-            self.n_spins,
-            out=self.equal,
+            energies,
+            self.energies,
+            out=self.stable_agents,
         )
-
-    def __store_spins(self, sampled_spins: torch.Tensor) -> None:
-        self.current_spins = sampled_spins.clone()
+        self.energies = energies
 
     def __get_number_newly_bifurcated_agents(self) -> int:
         return torch.count_nonzero(self.newly_bifurcated).item()
 
     def update(self, sampled_spins: torch.Tensor):
-        self.__compare_spins(sampled_spins)
+        self.__compare_energies(sampled_spins)
         self.__update_stability_streak()
         self.__update_bifurcated_spins()
         self.__set_newly_bifurcated_spins()
         self.__set_previously_bifurcated_spins()
         self.__update_final_spins(sampled_spins)
-        self.__store_spins(sampled_spins)
         self.progress.update(self.__get_number_newly_bifurcated_agents())
 
     def must_continue(self) -> bool:

--- a/tests/test_stop_window.py
+++ b/tests/test_stop_window.py
@@ -88,7 +88,7 @@ def test_wrong_convergence_threshold_value():
 def test_use_scenario():
     """
     Ground state is degenerate: [-1, 1, -1] and [1, -1, 1]
-    both reach the minimal energie value -6.
+    both reach the minimal energy value -6.
 
     Test of the stop window's behavior on 2 agents:
     - agent 1 converges to an optimal vector from step 3;

--- a/tests/test_stop_window.py
+++ b/tests/test_stop_window.py
@@ -3,7 +3,6 @@ import torch
 
 from src.simulated_bifurcation.optimizer import StopWindow
 
-
 TENSOR = torch.tensor([[1.0, 0.5, -1.0], [0.5, 0.0, 1.0], [-1.0, 1.0, -2.0]])
 CONVERGENCE_THRESHOLD = 3
 SPINS = 3

--- a/tests/test_stop_window.py
+++ b/tests/test_stop_window.py
@@ -3,14 +3,24 @@ import torch
 
 from src.simulated_bifurcation.optimizer import StopWindow
 
+
+TENSOR = torch.tensor([[1.0, 0.5, -1.0], [0.5, 0.0, 1.0], [-1.0, 1.0, -2.0]])
 CONVERGENCE_THRESHOLD = 3
 SPINS = 3
 AGENTS = 2
 SCENARIO = [
     torch.tensor(
         [
-            [1, -1],
             [-1, -1],
+            [1, -1],
+            [1, -1],
+        ],
+        dtype=torch.float32,
+    ),
+    torch.tensor(
+        [
+            [-1, -1],
+            [-1, 1],
             [1, -1],
         ],
         dtype=torch.float32,
@@ -18,32 +28,24 @@ SCENARIO = [
     torch.tensor(
         [
             [-1, 1],
+            [1, -1],
+            [-1, 1],
+        ],
+        dtype=torch.float32,
+    ),
+    torch.tensor(
+        [
             [-1, -1],
             [1, 1],
+            [-1, -1],
         ],
         dtype=torch.float32,
     ),
     torch.tensor(
         [
             [-1, 1],
-            [-1, -1],
             [1, -1],
-        ],
-        dtype=torch.float32,
-    ),
-    torch.tensor(
-        [
             [-1, 1],
-            [-1, -1],
-            [1, -1],
-        ],
-        dtype=torch.float32,
-    ),
-    torch.tensor(
-        [
-            [-1, 1],
-            [-1, -1],
-            [1, -1],
         ],
         dtype=torch.float32,
     ),
@@ -52,7 +54,7 @@ SCENARIO = [
 
 def test_init_window():
     window = StopWindow(
-        SPINS,
+        TENSOR,
         AGENTS,
         CONVERGENCE_THRESHOLD,
         dtype=torch.float32,
@@ -63,7 +65,6 @@ def test_init_window():
     assert window.n_agents == 2
     assert window.convergence_threshold == 3
     assert window.shape == (3, 2)
-    assert torch.equal(window.current_spins, torch.zeros((3, 2)))
     assert torch.equal(window.final_spins, torch.zeros((3, 2)))
 
 
@@ -71,21 +72,31 @@ def test_wrong_convergence_threshold_value():
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker
         StopWindow(
-            SPINS, AGENTS, 30.0, dtype=torch.float32, device="cpu", verbose=False
+            TENSOR, AGENTS, 30.0, dtype=torch.float32, device="cpu", verbose=False
         )
     with pytest.raises(ValueError):
-        StopWindow(SPINS, AGENTS, 0, dtype=torch.float32, device="cpu", verbose=False)
-    with pytest.raises(ValueError):
-        StopWindow(SPINS, AGENTS, -42, dtype=torch.float32, device="cpu", verbose=False)
+        StopWindow(TENSOR, AGENTS, 0, dtype=torch.float32, device="cpu", verbose=False)
     with pytest.raises(ValueError):
         StopWindow(
-            SPINS, AGENTS, 2**15, dtype=torch.float32, device="cpu", verbose=False
+            TENSOR, AGENTS, -42, dtype=torch.float32, device="cpu", verbose=False
+        )
+    with pytest.raises(ValueError):
+        StopWindow(
+            TENSOR, AGENTS, 2**15, dtype=torch.float32, device="cpu", verbose=False
         )
 
 
 def test_use_scenario():
+    """
+    Ground state is degenerate: [-1, 1, -1] and [1, -1, 1]
+    both reach the minimal energie value -6.
+
+    Test of the stop window's behavior on 2 agents:
+    - agent 1 converges to an optimal vector from step 3;
+    - agent 2 oscillates in the optimal space from step 2.
+    """
     window = StopWindow(
-        SPINS,
+        TENSOR,
         AGENTS,
         CONVERGENCE_THRESHOLD,
         dtype=torch.float32,
@@ -93,15 +104,18 @@ def test_use_scenario():
         verbose=False,
     )
 
-    # First update
+    #  Initial state
     assert torch.equal(
         window.previously_bifurcated, torch.tensor([False, False], dtype=torch.bool)
     )
+    assert torch.all(torch.isinf(window.energies))
+
+    #  First update
     window.update(SCENARIO[0])
     assert window.must_continue()
     assert not window.has_bifurcated_spins()
     assert torch.equal(window.get_bifurcated_spins(SCENARIO[0]), SCENARIO[0])
-    assert torch.equal(window.current_spins, SCENARIO[0])
+    assert torch.equal(window.energies, torch.tensor([2.0, 0.0]))
     assert torch.equal(window.final_spins, torch.zeros((3, 2)))
     assert torch.equal(window.stability, torch.tensor([0, 0], dtype=torch.int16))
     assert torch.equal(
@@ -110,9 +124,11 @@ def test_use_scenario():
     assert torch.equal(
         window.bifurcated, torch.tensor([False, False], dtype=torch.bool)
     )
-    assert torch.equal(window.equal, torch.tensor([False, False], dtype=torch.bool))
+    assert torch.equal(
+        window.stable_agents, torch.tensor([False, False], dtype=torch.bool)
+    )
 
-    # Second update
+    #  Second update
     assert torch.equal(
         window.previously_bifurcated, torch.tensor([False, False], dtype=torch.bool)
     )
@@ -120,7 +136,7 @@ def test_use_scenario():
     assert window.must_continue()
     assert not window.has_bifurcated_spins()
     assert torch.equal(window.get_bifurcated_spins(SCENARIO[1]), SCENARIO[1])
-    assert torch.equal(window.current_spins, SCENARIO[1])
+    assert torch.equal(window.energies, torch.tensor([0.0, -6.0]))
     assert torch.equal(window.final_spins, torch.zeros((3, 2)))
     assert torch.equal(window.stability, torch.tensor([0, 0], dtype=torch.int16))
     assert torch.equal(
@@ -129,9 +145,11 @@ def test_use_scenario():
     assert torch.equal(
         window.bifurcated, torch.tensor([False, False], dtype=torch.bool)
     )
-    assert torch.equal(window.equal, torch.tensor([False, False], dtype=torch.bool))
+    assert torch.equal(
+        window.stable_agents, torch.tensor([False, False], dtype=torch.bool)
+    )
 
-    # Third update
+    #  Third update
     assert torch.equal(
         window.previously_bifurcated, torch.tensor([False, False], dtype=torch.bool)
     )
@@ -139,18 +157,20 @@ def test_use_scenario():
     assert window.must_continue()
     assert not window.has_bifurcated_spins()
     assert torch.equal(window.get_bifurcated_spins(SCENARIO[2]), SCENARIO[2])
-    assert torch.equal(window.current_spins, SCENARIO[2])
+    assert torch.equal(window.energies, torch.tensor([-6.0, -6.0]))
     assert torch.equal(window.final_spins, torch.zeros((3, 2)))
-    assert torch.equal(window.stability, torch.tensor([1, 0], dtype=torch.int16))
+    assert torch.equal(window.stability, torch.tensor([0, 1], dtype=torch.int16))
     assert torch.equal(
         window.newly_bifurcated, torch.tensor([False, False], dtype=torch.bool)
     )
     assert torch.equal(
         window.bifurcated, torch.tensor([False, False], dtype=torch.bool)
     )
-    assert torch.equal(window.equal, torch.tensor([True, False], dtype=torch.bool))
+    assert torch.equal(
+        window.stable_agents, torch.tensor([False, True], dtype=torch.bool)
+    )
 
-    # Fourth update
+    #  Fourth update
     assert torch.equal(
         window.previously_bifurcated, torch.tensor([False, False], dtype=torch.bool)
     )
@@ -158,38 +178,62 @@ def test_use_scenario():
     assert window.must_continue()
     assert window.has_bifurcated_spins()
     assert torch.equal(window.get_bifurcated_spins(SCENARIO[3]), SCENARIO[3])
-    assert torch.equal(window.current_spins, SCENARIO[3])
+    assert torch.equal(window.energies, torch.tensor([-6.0, -6.0]))
     assert torch.equal(
         window.final_spins,
         torch.tensor(
             [
-                [-1, 0],
-                [-1, 0],
-                [1, 0],
+                [0, -1],
+                [0, 1],
+                [0, -1],
             ],
             dtype=torch.float32,
         ),
     )
-    assert torch.equal(window.stability, torch.tensor([2, 1], dtype=torch.float32))
+    assert torch.equal(window.stability, torch.tensor([1, 2], dtype=torch.float32))
     assert torch.equal(
-        window.newly_bifurcated, torch.tensor([True, False], dtype=torch.bool)
+        window.newly_bifurcated, torch.tensor([False, True], dtype=torch.bool)
     )
-    assert torch.equal(window.bifurcated, torch.tensor([True, False], dtype=torch.bool))
-    assert torch.equal(window.equal, torch.tensor([True, True], dtype=torch.bool))
-
-    # Fourth update
+    assert torch.equal(window.bifurcated, torch.tensor([False, True], dtype=torch.bool))
     assert torch.equal(
-        window.previously_bifurcated, torch.tensor([True, False], dtype=torch.bool)
+        window.stable_agents, torch.tensor([True, True], dtype=torch.bool)
+    )
+
+    #  Fourth update
+    assert torch.equal(
+        window.previously_bifurcated, torch.tensor([False, True], dtype=torch.bool)
     )
     window.update(SCENARIO[4])
     assert not window.must_continue()
     assert window.has_bifurcated_spins()
-    assert torch.equal(window.get_bifurcated_spins(SCENARIO[4]), SCENARIO[4])
-    assert torch.equal(window.current_spins, SCENARIO[4])
-    assert torch.equal(window.final_spins, SCENARIO[4])
+    assert torch.equal(
+        window.get_bifurcated_spins(SCENARIO[4]),
+        torch.tensor(
+            [
+                [-1, -1],
+                [1, 1],
+                [-1, -1],
+            ],
+            dtype=torch.float32,
+        ),
+    )
+    assert torch.equal(window.energies, torch.tensor([-6.0, -6.0]))
+    assert torch.equal(
+        window.final_spins,
+        torch.tensor(
+            [
+                [-1, -1],
+                [1, 1],
+                [-1, -1],
+            ],
+            dtype=torch.float32,
+        ),
+    )
     assert torch.equal(window.stability, torch.tensor([2, 2], dtype=torch.int16))
     assert torch.equal(
-        window.newly_bifurcated, torch.tensor([False, True], dtype=torch.bool)
+        window.newly_bifurcated, torch.tensor([True, False], dtype=torch.bool)
     )
     assert torch.equal(window.bifurcated, torch.tensor([True, True], dtype=torch.bool))
-    assert torch.equal(window.equal, torch.tensor([True, True], dtype=torch.bool))
+    assert torch.equal(
+        window.stable_agents, torch.tensor([True, True], dtype=torch.bool)
+    )


### PR DESCRIPTION
# 💬 Pull Request Description

Following the discussion #30, we decided to slightly change the behavior of the stop window so that the energy is the convergence criterion instead of the spins. This allows to deal with the cases in which there are degenerate energy levels. Thus, even though the spins may oscillate in a constant-energy-space, they would still be considered as steady by the window as they account for the same energy.

Besides, since the Ising energy is the objective function that SB seeks to minimize, setting it as the convergence criterion makes perfect sense.

# ✔️ Check list

_Before you open the pull request, make sure the following requirements are met._

- [x] The code matches the styling rules
- [x] The new code is covered by relevant tests
- [x] Documentation was added

# 🚀 New features

No new feature was added, except that the stop window now focuses on the energy of the agents instead of the spins.

# 🐞 Bug fixes

None.

# 📣 Supplementary information

None.