### PR TITLE
warnings.warn

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run tests with Pytest
         run: |
-          coverage run -m pytest -p no:warnings
+          coverage run -m pytest
 
       - name: Coverage
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run tests with Pytest
         run: |
-          coverage run -m pytest
+          coverage run -m pytest -p no:warnings
 
       - name: Coverage
         run: |

--- a/src/simulated_bifurcation/__init__.py
+++ b/src/simulated_bifurcation/__init__.py
@@ -152,7 +152,7 @@ tensor([0., 0.], device='cuda:0')
 
 
 from . import models
-from .optimizer import get_env, reset_env, set_env
+from .optimizer import ConvergenceWarning, get_env, reset_env, set_env
 from .polynomial import (
     BinaryPolynomial,
     BinaryQuadraticPolynomial,

--- a/src/simulated_bifurcation/optimizer/__init__.py
+++ b/src/simulated_bifurcation/optimizer/__init__.py
@@ -1,5 +1,8 @@
 from .optimization_variables import get_env, reset_env, set_env
 from .optimizer_mode import OptimizerMode
-from .simulated_bifurcation_optimizer import SimulatedBifurcationOptimizer
+from .simulated_bifurcation_optimizer import (
+    ConvergenceWarning,
+    SimulatedBifurcationOptimizer,
+)
 from .stop_window import StopWindow
 from .symplectic_integrator import SymplecticIntegrator

--- a/src/simulated_bifurcation/optimizer/simulated_bifurcation_optimizer.py
+++ b/src/simulated_bifurcation/optimizer/simulated_bifurcation_optimizer.py
@@ -1,6 +1,7 @@
 import logging
+import warnings
 from time import time
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple
 
 import torch
 from numpy import minimum
@@ -251,7 +252,7 @@ class SimulatedBifurcationOptimizer:
         """
         if use_window:
             if not self.window.has_bifurcated_spins():
-                LOGGER.warning(
+                warnings.warn(
                     "No agent has converged. Returned final positions' signs instead."
                 )
             return self.window.get_bifurcated_spins(spins)

--- a/src/simulated_bifurcation/optimizer/simulated_bifurcation_optimizer.py
+++ b/src/simulated_bifurcation/optimizer/simulated_bifurcation_optimizer.py
@@ -21,6 +21,11 @@ CONSOLE_HANDLER.setFormatter(
 LOGGER.addHandler(CONSOLE_HANDLER)
 
 
+class ConvergenceWarning(Warning):
+    def __str__(self) -> str:
+        return "No agent has converged. Returned final positions' signs instead."
+
+
 class SimulatedBifurcationOptimizer:
 
     """
@@ -252,9 +257,7 @@ class SimulatedBifurcationOptimizer:
         """
         if use_window:
             if not self.window.has_bifurcated_spins():
-                warnings.warn(
-                    "No agent has converged. Returned final positions' signs instead."
-                )
+                warnings.warn(ConvergenceWarning(), stacklevel=2)
             return self.window.get_bifurcated_spins(spins)
         else:
             return spins

--- a/tests/models/test_knapsack.py
+++ b/tests/models/test_knapsack.py
@@ -4,7 +4,7 @@ from src.simulated_bifurcation import set_env
 from src.simulated_bifurcation.models import Knapsack
 
 
-def test_markowitz():
+def test_knapsack():
     torch.manual_seed(42)
     weights = [12, 1, 1, 4, 2]
     prices = [4, 2, 1, 10, 2]
@@ -17,7 +17,7 @@ def test_markowitz():
         "status": "not optimized",
     }
 
-    model.minimize(verbose=False)
+    model.minimize(ballistic=True, verbose=False)
     assert model.summary["items"] == [1, 2, 3, 4]
     assert model.summary["total_cost"] == 15
     assert model.summary["total_weight"] == 8

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -6,6 +6,7 @@ import torch
 from src.simulated_bifurcation import reset_env, set_env
 from src.simulated_bifurcation.ising_core import IsingCore
 from src.simulated_bifurcation.optimizer import (
+    ConvergenceWarning,
     OptimizerMode,
     SimulatedBifurcationOptimizer,
 )
@@ -48,16 +49,17 @@ def test_optimizer_without_bifurcation():
     )
     h = torch.tensor([1, 0, -2], dtype=torch.float32)
     ising = IsingCore(J, h)
-    ising.minimize(
-        5,
-        10,
-        False,
-        False,
-        False,
-        use_window=True,
-        sampling_period=50,
-        convergence_threshold=50,
-    )
+    with pytest.warns(ConvergenceWarning):
+        ising.minimize(
+            5,
+            10,
+            False,
+            False,
+            False,
+            use_window=True,
+            sampling_period=50,
+            convergence_threshold=50,
+        )
     assert torch.equal(
         torch.tensor(
             [

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -3,10 +3,9 @@ from time import time
 import pytest
 import torch
 
-from src.simulated_bifurcation import reset_env, set_env
+from src.simulated_bifurcation import ConvergenceWarning, reset_env, set_env
 from src.simulated_bifurcation.ising_core import IsingCore
 from src.simulated_bifurcation.optimizer import (
-    ConvergenceWarning,
     OptimizerMode,
     SimulatedBifurcationOptimizer,
 )


### PR DESCRIPTION
# 💬 Pull Request Description

Following discussion #30 and issue #34, the `logging.warn` has been replaced by `warnings.warn` to warn when some agents did not converged if the stop window is enabled.

# ✔️ Check list

_Before you open the pull request, make sure the following requirements are met._

- [x] The code matches the styling rules
- [x] The new code is covered by relevant tests
- [x] Documentation was added

# 🚀 New features

- `ConvergenceWarning`

# 🐞 Bug fixes

- Renamed `test_markowitz` to `test_knapsack` in test_knapsack.py

# 📣 Supplementary information

- Modified `test_knapsack` to improve convergence