### PR TITLE
V1.2.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,6 +9,6 @@ authors:
 - family-names: Pugliese
   given-names: Lorenzo
 title: "Simulated Bifurcation (SB) algorithm for Python"
-version: 1.2.0
+version: 1.2.1
 date-released: 2023-08-11
 url: "https://github.com/bqth29/simulated-bifurcation-algorithm"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This can also be seen as the sum of a quadratic form, a linear form and a consta
 
 The `minimize` and `maximize` functions allow to respectively minimize and maximize the value of such polynomials for a given type of input values, relying on the SB algorithm. They both return the optimal polynomial value found by the SB algorithm, along with its associated input vector.
 
-The input types must be passed to the `input_type` argument:
+The input types must be passed to the `domain` argument:
 
 - `spin` (default value) for a spin optimization: the optimal vector will only have ±1 values
 - `binary` for a binary optimization: the optimal vector will only have 0 or 1 values
@@ -92,26 +92,26 @@ constant = 2.0
 
 ```python
 # Spin minimization
-spin_value, spin_vector = sb.minimize(matrix, vector, constant, input_type='spin')
+spin_value, spin_vector = sb.minimize(matrix, vector, constant, domain='spin')
 
 # Binary minimization
-binary_value, binary_vector = sb.minimize(matrix, vector, constant, input_type='binary')
+binary_value, binary_vector = sb.minimize(matrix, vector, constant, domain='binary')
 
 # 3-bits integer minimization
-int_value, int_vector = sb.minimize(matrix, vector, constant, input_type='int3')
+int_value, int_vector = sb.minimize(matrix, vector, constant, domain='int3')
 ```
 
 #### Maximization
 
 ```python
 # Spin maximization
-spin_value, spin_vector = sb.maximize(matrix, vector, constant, input_type='spin')
+spin_value, spin_vector = sb.maximize(matrix, vector, constant, domain='spin')
 
 # Binary maximization
-binary_value, binary_vector = sb.maximize(matrix, vector, constant, input_type='binary')
+binary_value, binary_vector = sb.maximize(matrix, vector, constant, domain='binary')
 
 # 10-bits integer maximization
-int_value, int_vector = sb.maximize(matrix, vector, constant, input_type='int10')
+int_value, int_vector = sb.maximize(matrix, vector, constant, domain='int10')
 ```
 
 > For both functions, only the matrix is required, the vector and constant terms are optional.

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ If you are using this code for your own projects please cite our work:
     month = aug,
     title = {{Simulated Bifurcation (SB) algorithm for Python}},
     url = {https://github.com/bqth29/simulated-bifurcation-algorithm},
-    version = {1.2.0},
+    version = {1.2.1},
     year = {2023},
 }
 ```

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as readme:
 
 
 # !MDC{set}{package_version = "{version}"}
-package_version = "1.2.1.dev0"
+package_version = "1.2.1"
 
 
 dependencies = [

--- a/src/simulated_bifurcation/__init__.py
+++ b/src/simulated_bifurcation/__init__.py
@@ -35,18 +35,26 @@ that simulated_bifurcation has been imported as `sb`:
 Code snippets are indicated by three greater-than signs:
 
   >>> x = 42
-  >>> x = x + 1
+  >>> x += 1
 
 .. deprecated:: 1.2.1
-    `BinaryPolynomial` will be modified in simulated-bifurcation 1.3.0, it
-    is replaced by `BinaryQuadraticPolynomial` in prevision of the addition
-    of multivariate polynomials of an arbitrary degree.
-    `IntegerPolynomial` will be modified in simulated-bifurcation 1.3.0, it
-    is replaced by `IntegerQuadraticPolynomial` in prevision of the
-    addition of multivariate polynomials of an arbitrary degree.
-    `SpinPolynomial` will be modified in simulated-bifurcation 1.3.0, it is
-    replaced by `SpinQuadraticPolynomial` in prevision of the addition of
-    multivariate polynomials of an arbitrary degree.
+    The functions `sb.optimize`, `sb.minimize`, and `sb.maximize` will be
+    modified in simulated-bifurcation 1.3.0. The `matrix`, `vector`, and
+    `constant` parameters will become positional-only parameters; the other
+    parameters will become keyword-only parameters.
+
+    In simulated-bifurcation 1.3.0, parameters `input_type` will be
+    removed. Use `domain` instead.
+
+    `BinaryPolynomial`, `BinaryQuadraticPolynomial`, `IntegerPolynomial`,
+    `IntegerQuadraticPolynomial`, `SpinPolynomial`, and
+    `SpinQuadraticPolynomial` will be removed in simulated-bifurcation
+    1.3.0. Achieving a similar behaviour will be done by using the
+    `domain` parameter when creating a polynomial.
+
+    `BaseMultivariateQuadraticPolynomial` and `IsingPolynomialInterface`
+    will be removed in simulated-bifurcation 1.3.0. They are replaced by
+    `QuadraticPolynomial`.
 
 Notes
 -----

--- a/src/simulated_bifurcation/__init__.py
+++ b/src/simulated_bifurcation/__init__.py
@@ -176,4 +176,4 @@ reset_env()
 
 
 # !MDC{set}{__version__ = "{version}"}
-__version__ = "1.2.1.dev0"
+__version__ = "1.2.1"

--- a/src/simulated_bifurcation/__init__.py
+++ b/src/simulated_bifurcation/__init__.py
@@ -49,8 +49,10 @@ Code snippets are indicated by three greater-than signs:
     `BinaryPolynomial`, `BinaryQuadraticPolynomial`, `IntegerPolynomial`,
     `IntegerQuadraticPolynomial`, `SpinPolynomial`, and
     `SpinQuadraticPolynomial` will be removed in simulated-bifurcation
-    1.3.0. Achieving a similar behaviour will be done by using the
-    `domain` parameter when creating a polynomial.
+    1.3.0.  From version 1.3.0 onwards, polynomials will no longer have a
+    definition domain. The domain only needs to be specified when creating
+    an Ising model, and conversely when converting spins back into the
+    original domain.
 
     `BaseMultivariateQuadraticPolynomial` and `IsingPolynomialInterface`
     will be removed in simulated-bifurcation 1.3.0. They are replaced by

--- a/src/simulated_bifurcation/models/ising.py
+++ b/src/simulated_bifurcation/models/ising.py
@@ -24,6 +24,8 @@ class Ising(SpinQuadraticPolynomial):
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
     ) -> None:
-        super().__init__(-0.5 * J, h, None, dtype, device)
+        super().__init__(
+            -0.5 * J, h, None, dtype, device, silence_deprecation_warning=True
+        )
         self.J = J
         self.h = h

--- a/src/simulated_bifurcation/models/knapsack.py
+++ b/src/simulated_bifurcation/models/knapsack.py
@@ -28,7 +28,14 @@ class Knapsack(BinaryQuadraticPolynomial):
         self.max_weight = max_weight
         matrix = self.__make_matrix(dtype, device)
         vector = self.__make_vector(dtype, device)
-        super().__init__(matrix, vector, self.__make_penalty(), dtype, device)
+        super().__init__(
+            matrix,
+            vector,
+            self.__make_penalty(),
+            dtype,
+            device,
+            silence_deprecation_warning=True,
+        )
 
     @property
     def summary(self) -> Dict[str, Union[int, float, List[int]]]:

--- a/src/simulated_bifurcation/models/markowitz.py
+++ b/src/simulated_bifurcation/models/markowitz.py
@@ -39,7 +39,15 @@ class SequentialMarkowitz(IntegerQuadraticPolynomial):
         )
 
         matrix, vector, constant = self.compile_model()
-        super().__init__(matrix, vector, constant, number_of_bits, dtype, device)
+        super().__init__(
+            matrix,
+            vector,
+            constant,
+            number_of_bits,
+            dtype,
+            device,
+            silence_deprecation_warning=True,
+        )
 
     def compile_model(self) -> Tuple[torch.Tensor, torch.Tensor, float]:
         matrix = self.__compile_matrix()

--- a/src/simulated_bifurcation/models/number_partitioning.py
+++ b/src/simulated_bifurcation/models/number_partitioning.py
@@ -23,7 +23,14 @@ class NumberPartitioning(SpinQuadraticPolynomial):
         tensor_numbers = torch.tensor(self.numbers, dtype=dtype, device=device).reshape(
             -1, 1
         )
-        super().__init__(tensor_numbers @ tensor_numbers.t(), None, None, dtype, device)
+        super().__init__(
+            tensor_numbers @ tensor_numbers.t(),
+            None,
+            None,
+            dtype,
+            device,
+            silence_deprecation_warning=True,
+        )
 
     @property
     def partition(self) -> Dict[str, Dict[str, Union[List[int], int, None]]]:

--- a/src/simulated_bifurcation/models/qubo.py
+++ b/src/simulated_bifurcation/models/qubo.py
@@ -21,5 +21,5 @@ class QUBO(BinaryQuadraticPolynomial):
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
     ) -> None:
-        super().__init__(Q, None, None, dtype, device)
+        super().__init__(Q, None, None, dtype, device, silence_deprecation_warning=True)
         self.Q = self.matrix

--- a/src/simulated_bifurcation/polynomial/__init__.py
+++ b/src/simulated_bifurcation/polynomial/__init__.py
@@ -2,19 +2,15 @@
 Implementation of multivariate degree 2 polynomials.
 
 .. deprecated:: 1.2.1
-    `IsingPolynomialInterface` will be removed in simulated-bifurcation
-    1.3.0, it is replaced by `BaseMultivariateQuadraticPolynomial` in
-    prevision of the addition of multivariate polynomials of an arbitrary
-    degree.
-    `BinaryPolynomial` will be modified in simulated-bifurcation 1.3.0, it
-    is replaced by `BinaryQuadraticPolynomial` in prevision of the addition
-    of multivariate polynomials of an arbitrary degree.
-    `IntegerPolynomial` will be modified in simulated-bifurcation 1.3.0, it
-    is replaced by `IntegerQuadraticPolynomial` in prevision of the
-    addition of multivariate polynomials of an arbitrary degree.
-    `SpinPolynomial` will be modified in simulated-bifurcation 1.3.0, it is
-    replaced by `SpinQuadraticPolynomial` in prevision of the addition of
-    multivariate polynomials of an arbitrary degree.
+     `BinaryPolynomial`, `BinaryQuadraticPolynomial`, `IntegerPolynomial`,
+    `IntegerQuadraticPolynomial`, `SpinPolynomial`, and
+    `SpinQuadraticPolynomial` will be removed in simulated-bifurcation
+    1.3.0. Achieving a similar behaviour will be done by using the
+    `domain` parameter when creating a polynomial.
+
+    `BaseMultivariateQuadraticPolynomial` and `IsingPolynomialInterface`
+    will be removed in simulated-bifurcation 1.3.0. They are replaced by
+    `QuadraticPolynomial`.
 
 Multivariate degree 2 polynomials are the sum of a quadratic form and a
 linear form plus a constant term:

--- a/src/simulated_bifurcation/polynomial/__init__.py
+++ b/src/simulated_bifurcation/polynomial/__init__.py
@@ -5,8 +5,10 @@ Implementation of multivariate degree 2 polynomials.
      `BinaryPolynomial`, `BinaryQuadraticPolynomial`, `IntegerPolynomial`,
     `IntegerQuadraticPolynomial`, `SpinPolynomial`, and
     `SpinQuadraticPolynomial` will be removed in simulated-bifurcation
-    1.3.0. Achieving a similar behaviour will be done by using the
-    `domain` parameter when creating a polynomial.
+    1.3.0. From version 1.3.0 onwards, polynomials will no longer have a
+    definition domain. The domain only needs to be specified when creating
+    an Ising model, and conversely when converting spins back into the
+    original domain.
 
     `BaseMultivariateQuadraticPolynomial` and `IsingPolynomialInterface`
     will be removed in simulated-bifurcation 1.3.0. They are replaced by

--- a/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/base_multivariate_polynomial.py
@@ -1,9 +1,8 @@
 """
 .. deprecated:: 1.2.1
-    `IsingPolynomialInterface` will be removed in simulated-bifurcation
-    1.3.0, it is replaced by `BaseMultivariateQuadraticPolynomial` in
-    prevision of the addition of multivariate polynomials of an arbitrary
-    degree.
+    `BaseMultivariateQuadraticPolynomial` and `IsingPolynomialInterface`
+    will be removed in simulated-bifurcation 1.3.0. They are replaced by
+    `QuadraticPolynomial`.
 
 """
 
@@ -25,6 +24,10 @@ class BaseMultivariateQuadraticPolynomial(ABC):
     be translated as an equivalent Ising problem to be solved with the
     Simulated Bifurcation algorithm.
 
+    .. deprecated:: 1.2.1
+      `BaseMultivariateQuadraticPolynomial` will be removed in
+      simulated-bifurcation 1.3.0. It is replaced by `QuadraticPolynomial`.
+
     The polynomial is the combination of a quadratic and a linear form plus a
     constant term:
 
@@ -41,6 +44,8 @@ class BaseMultivariateQuadraticPolynomial(ABC):
         accepted_values: Union[torch.Tensor, np.ndarray, List[int], None] = None,
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
+        *,
+        silence_deprecation_warning=False,
     ) -> None:
         """
         Parameters
@@ -66,6 +71,14 @@ class BaseMultivariateQuadraticPolynomial(ABC):
             the device on which to perform the computations of the Simulated
             Bifurcation algorithm (default `"cpu"`)
         """
+        if not silence_deprecation_warning:
+            # 2023-11-21, 1.2.1
+            warnings.warn(
+                "`BaseMultivariateQuadraticPolynomial` will be removed in "
+                "simulated-bifurcation 1.3.0. It is replaced by `QuadraticPolynomial`.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
         self.__check_device(device)
         self.__init_matrix(matrix, dtype, device)
         self.__init_vector(vector, dtype, device)
@@ -622,9 +635,7 @@ class IsingPolynomialInterface(BaseMultivariateQuadraticPolynomial, ABC):
     """
     .. deprecated:: 1.2.1
         `IsingPolynomialInterface` will be removed in simulated-bifurcation
-        1.3.0, it is replaced by `BaseMultivariateQuadraticPolynomial` in
-        prevision of the addition of multivariate polynomials of an
-        arbitrary degree.
+        1.3.0, it is replaced by `QuadraticPolynomial`.
 
     """
 
@@ -633,8 +644,8 @@ class IsingPolynomialInterface(BaseMultivariateQuadraticPolynomial, ABC):
         warnings.warn(
             "`IsingPolynomialInterface` is deprecated as of simulated-bifurcation "
             "1.2.1, and will be removed in simulated-bifurcation 1.3.0. Please use "
-            "`BaseQuadraticMultivariatePolynomial` instead.",
+            "`QuadraticPolynomial` instead.",
             DeprecationWarning,
             stacklevel=3,
         )
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs, silence_deprecation_warning=True)

--- a/src/simulated_bifurcation/polynomial/binary_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/binary_polynomial.py
@@ -2,9 +2,11 @@
 Implementation of multivariate degree 2 polynomials over binary vectors.
 
 .. deprecated:: 1.2.1
-  `BinaryPolynomial` and `BinaryQuadraticPolynomial`. Achieving a similar
-  behaviour will be done by setting `domain="binary"` when creating a
-  polynomial.
+  `BinaryPolynomial` and `BinaryQuadraticPolynomial` will be removed in
+  simulated-bifurcation 1.3.0. From version 1.3.0 onwards, polynomials will
+  no longer have a definition domain. The domain only needs to be specified
+  when creating an Ising model, and conversely when converting spins back
+  into the original domain.
 
 Multivariate degree 2 polynomials are the sum of a quadratic form and a
 linear form plus a constant term:
@@ -49,9 +51,11 @@ class BinaryQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
     Multivariate degree 2 polynomials over binary vectors.
 
     .. deprecated:: 1.2.1
-        `BinaryQuadraticPolynomial` will be removed in
-        simulated-bifurcation 1.3.0. Achieving a similar behaviour will be
-        done by setting `domain="binary"` when creating a polynomial.
+      `BinaryQuadraticPolynomial` will be removed in simulated-bifurcation
+      1.3.0. From version 1.3.0 onwards, polynomials will no longer have a
+      definition domain. The domain only needs to be specified when
+      creating an Ising model, and conversely when converting spins back
+      into the original domain.
 
     Multivariate degree 2 polynomials are the sum of a quadratic form and a
     linear form plus a constant term:
@@ -126,8 +130,10 @@ class BinaryQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
             warnings.warn(
                 "`BinaryQuadraticPolynomial` is deprecated as of simulated-bifurcation "
                 "1.2.1, and it will be removed in simulated-bifurcation 1.3.0. "
-                "Achieving a similar behaviour will be done by setting "
-                '`domain="binary"` when creating a polynomial.',
+                "From version 1.3.0 onwards, polynomials will no longer have a "
+                "definition domain. The domain only needs to be specified when "
+                "creating an Ising model, and conversely when converting spins "
+                "back into the original domain.",
                 DeprecationWarning,
                 stacklevel=3,
             )
@@ -177,9 +183,11 @@ class BinaryPolynomial(BinaryQuadraticPolynomial):
 
     """
     .. deprecated:: 1.2.1
-        `BinaryPolynomial` will be removed in simulated-bifurcation 1.3.0.
-        Achieving a similar behaviour will be done by setting
-        `domain="binary"` when creating a polynomial.
+      `BinaryPolynomial` will be removed in simulated-bifurcation 1.3.0.
+      From version 1.3.0 onwards, polynomials will no longer have a
+      definition domain. The domain only needs to be specified when
+      creating an Ising model, and conversely when converting spins back
+      into the original domain.
 
     """
 
@@ -187,9 +195,10 @@ class BinaryPolynomial(BinaryQuadraticPolynomial):
         # 2023-10-03, 1.2.1
         warnings.warn(
             "`BinaryPolynomial` is deprecated as of simulated-bifurcation 1.2.1, and "
-            "it will be removed in simulated-bifurcation 1.3.0. Achieving a similar "
-            'behaviour will be done by setting `domain="binary"` when creating a '
-            "polynomial.",
+            "it will be removed in simulated-bifurcation 1.3.0. From version 1.3.0 "
+            "onwards, polynomials will no longer have a definition domain. The domain "
+            "only needs to be specified when creating an Ising model, and conversely "
+            "when converting spins back into the original domain.",
             DeprecationWarning,
             stacklevel=3,
         )

--- a/src/simulated_bifurcation/polynomial/binary_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/binary_polynomial.py
@@ -131,7 +131,15 @@ class BinaryQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
                 DeprecationWarning,
                 stacklevel=3,
             )
-        super().__init__(matrix, vector, constant, [0, 1], dtype, device)
+        super().__init__(
+            matrix,
+            vector,
+            constant,
+            [0, 1],
+            dtype,
+            device,
+            silence_deprecation_warning=True,
+        )
 
     def to_ising(self) -> IsingCore:
         symmetrical_matrix = IsingCore.symmetrize(self.matrix)

--- a/src/simulated_bifurcation/polynomial/binary_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/binary_polynomial.py
@@ -2,9 +2,9 @@
 Implementation of multivariate degree 2 polynomials over binary vectors.
 
 .. deprecated:: 1.2.1
-    `BinaryPolynomial` will be modified in simulated-bifurcation 1.3.0, it
-    is replaced by `BinaryQuadraticPolynomial` in prevision of the addition
-    of multivariate polynomials of an arbitrary degree.
+  `BinaryPolynomial` and `BinaryQuadraticPolynomial`. Achieving a similar
+  behaviour will be done by setting `domain="binary"` when creating a
+  polynomial.
 
 Multivariate degree 2 polynomials are the sum of a quadratic form and a
 linear form plus a constant term:
@@ -47,6 +47,11 @@ class BinaryQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
 
     """
     Multivariate degree 2 polynomials over binary vectors.
+
+    .. deprecated:: 1.2.1
+        `BinaryQuadraticPolynomial` will be removed in
+        simulated-bifurcation 1.3.0. Achieving a similar behaviour will be
+        done by setting `domain="binary"` when creating a polynomial.
 
     Multivariate degree 2 polynomials are the sum of a quadratic form and a
     linear form plus a constant term:
@@ -113,7 +118,19 @@ class BinaryQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
         constant: Union[float, int, None] = None,
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
+        *,
+        silence_deprecation_warning=False,
     ) -> None:
+        if not silence_deprecation_warning:
+            # 2023-11-21, 1.2.1
+            warnings.warn(
+                "`BinaryQuadraticPolynomial` is deprecated as of simulated-bifurcation "
+                "1.2.1, and it will be removed in simulated-bifurcation 1.3.0. "
+                "Achieving a similar behaviour will be done by setting "
+                '`domain="binary"` when creating a polynomial.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
         super().__init__(matrix, vector, constant, [0, 1], dtype, device)
 
     def to_ising(self) -> IsingCore:
@@ -152,9 +169,9 @@ class BinaryPolynomial(BinaryQuadraticPolynomial):
 
     """
     .. deprecated:: 1.2.1
-        `BinaryPolynomial` will be modified in simulated-bifurcation 1.3.0,
-        it is replaced by `BinaryQuadraticPolynomial` in prevision of the
-        addition of multivariate polynomials of an arbitrary degree.
+        `BinaryPolynomial` will be removed in simulated-bifurcation 1.3.0.
+        Achieving a similar behaviour will be done by setting
+        `domain="binary"` when creating a polynomial.
 
     """
 
@@ -162,9 +179,10 @@ class BinaryPolynomial(BinaryQuadraticPolynomial):
         # 2023-10-03, 1.2.1
         warnings.warn(
             "`BinaryPolynomial` is deprecated as of simulated-bifurcation 1.2.1, and "
-            "its behaviour will change in simulated-bifurcation 1.3.0. Please use "
-            "`BinaryQuadraticPolynomial` instead.",
+            "it will be removed in simulated-bifurcation 1.3.0. Achieving a similar "
+            'behaviour will be done by setting `domain="binary"` when creating a '
+            "polynomial.",
             DeprecationWarning,
             stacklevel=3,
         )
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs, silence_deprecation_warning=True)

--- a/src/simulated_bifurcation/polynomial/integer_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/integer_polynomial.py
@@ -2,10 +2,11 @@
 Implementation of multivariate degree 2 polynomials over integer vectors.
 
 .. deprecated:: 1.2.1
-  `IntegerPolynomial` and `IntegerQuadraticPolynomial`. Achieving a similar
-  behaviour will be done by setting `domain="int..."` when creating a
-  polynomial (where ... should be replaced by a positive integer
-  corresponding to the number of bits of the integers).
+  `IntegerPolynomial` and `IntegerQuadraticPolynomial` will be removed in
+  simulated-bifurcation 1.3.0. From version 1.3.0 onwards, polynomials will
+  no longer have a definition domain. The domain only needs to be specified
+  when creating an Ising model, and conversely when converting spins back
+  into the original domain.
 
 Multivariate degree 2 polynomials are the sum of a quadratic form and a
 linear form plus a constant term:
@@ -51,11 +52,11 @@ class IntegerQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
     Multivariate degree 2 polynomials over fixed bit-width integer vectors.
 
     .. deprecated:: 1.2.1
-        `IntegerQuadraticPolynomial` will be removed in
-        simulated-bifurcation 1.3.0. Achieving a similar behaviour will be
-        done by setting `domain="int..."` when creating a polynomial (where
-        ... should be replaced by a positive integer corresponding to the
-        number of bits of the integers).
+      `IntegerQuadraticPolynomial` will be removed in simulated-bifurcation
+      1.3.0. From version 1.3.0 onwards, polynomials will no longer have a
+      definition domain. The domain only needs to be specified when
+      creating an Ising model, and conversely when converting spins back
+      into the original domain.
 
     Multivariate degree 2 polynomials are the sum of a quadratic form and a
     linear form plus a constant term:
@@ -138,10 +139,10 @@ class IntegerQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
             warnings.warn(
                 "`IntegerQuadraticPolynomial` is deprecated as of simulated-bifurcation"
                 " 1.2.1, and it will be removed in simulated-bifurcation 1.3.0. "
-                "Achieving a similar behaviour will be done by setting "
-                '`domain="int..."` when creating a polynomial. (where ... should be '
-                "replaced by a positive integer corresponding to the number of bits of "
-                "the integers)",
+                "From version 1.3.0 onwards, polynomials will no longer have a "
+                "definition domain. The domain only needs to be specified when "
+                "creating an Ising model, and conversely when converting spins "
+                "back into the original domain.",
                 DeprecationWarning,
                 stacklevel=3,
             )
@@ -232,10 +233,10 @@ class IntegerPolynomial(IntegerQuadraticPolynomial):
         # 2023-10-03, 1.2.1
         warnings.warn(
             "`IntegerPolynomial` is deprecated as of simulated-bifurcation 1.2.1, and "
-            "it will be removed in simulated-bifurcation 1.3.0. Achieving a similar "
-            'behaviour will be done by setting `domain="int..."` when creating a '
-            "polynomial. (where ... should be replaced by a positive integer "
-            "corresponding to the number of bits of the integers)",
+            "it will be removed in simulated-bifurcation 1.3.0. From version 1.3.0 "
+            "onwards, polynomials will no longer have a definition domain. The domain "
+            "only needs to be specified when creating an Ising model, and conversely "
+            "when converting spins back into the original domain.",
             DeprecationWarning,
             stacklevel=3,
         )

--- a/src/simulated_bifurcation/polynomial/integer_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/integer_polynomial.py
@@ -148,7 +148,13 @@ class IntegerQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
         if not isinstance(number_of_bits, int) or number_of_bits < 1:
             raise ValueError("The number of bits must be a non-negative integer.")
         super().__init__(
-            matrix, vector, constant, [*range(2**number_of_bits)], dtype, device
+            matrix,
+            vector,
+            constant,
+            [*range(2**number_of_bits)],
+            dtype,
+            device,
+            silence_deprecation_warning=True,
         )
         self.number_of_bits = number_of_bits
         self.__int_to_bin_matrix = self.integer_to_binary_matrix(

--- a/src/simulated_bifurcation/polynomial/integer_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/integer_polynomial.py
@@ -2,9 +2,10 @@
 Implementation of multivariate degree 2 polynomials over integer vectors.
 
 .. deprecated:: 1.2.1
-    `IntegerPolynomial` will be modified in simulated-bifurcation 1.3.0, it
-    is replaced by `IntegerQuadraticPolynomial` in prevision of the
-    addition of multivariate polynomials of an arbitrary degree.
+  `IntegerPolynomial` and `IntegerQuadraticPolynomial`. Achieving a similar
+  behaviour will be done by setting `domain="int..."` when creating a
+  polynomial (where ... should be replaced by a positive integer
+  corresponding to the number of bits of the integers).
 
 Multivariate degree 2 polynomials are the sum of a quadratic form and a
 linear form plus a constant term:
@@ -48,6 +49,13 @@ class IntegerQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
 
     """
     Multivariate degree 2 polynomials over fixed bit-width integer vectors.
+
+    .. deprecated:: 1.2.1
+        `IntegerQuadraticPolynomial` will be removed in
+        simulated-bifurcation 1.3.0. Achieving a similar behaviour will be
+        done by setting `domain="int..."` when creating a polynomial (where
+        ... should be replaced by a positive integer corresponding to the
+        number of bits of the integers).
 
     Multivariate degree 2 polynomials are the sum of a quadratic form and a
     linear form plus a constant term:
@@ -122,7 +130,21 @@ class IntegerQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
         number_of_bits: int = 1,
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
+        *,
+        silence_deprecation_warning=False,
     ) -> None:
+        if not silence_deprecation_warning:
+            # 2023-11-21, 1.2.1
+            warnings.warn(
+                "`IntegerQuadraticPolynomial` is deprecated as of simulated-bifurcation"
+                " 1.2.1, and it will be removed in simulated-bifurcation 1.3.0. "
+                "Achieving a similar behaviour will be done by setting "
+                '`domain="int..."` when creating a polynomial. (where ... should be '
+                "replaced by a positive integer corresponding to the number of bits of "
+                "the integers)",
+                DeprecationWarning,
+                stacklevel=3,
+            )
         if not isinstance(number_of_bits, int) or number_of_bits < 1:
             raise ValueError("The number of bits must be a non-negative integer.")
         super().__init__(
@@ -204,9 +226,11 @@ class IntegerPolynomial(IntegerQuadraticPolynomial):
         # 2023-10-03, 1.2.1
         warnings.warn(
             "`IntegerPolynomial` is deprecated as of simulated-bifurcation 1.2.1, and "
-            "its behaviour will change in simulated-bifurcation 1.3.0. Please use "
-            "`IntegerQuadraticPolynomial` instead.",
+            "it will be removed in simulated-bifurcation 1.3.0. Achieving a similar "
+            'behaviour will be done by setting `domain="int..."` when creating a '
+            "polynomial. (where ... should be replaced by a positive integer "
+            "corresponding to the number of bits of the integers)",
             DeprecationWarning,
             stacklevel=3,
         )
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs, silence_deprecation_warning=True)

--- a/src/simulated_bifurcation/polynomial/spin_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/spin_polynomial.py
@@ -2,9 +2,11 @@
 Implementation of multivariate degree 2 polynomials over spin vectors.
 
 .. deprecated:: 1.2.1
-  `SpinPolynomial` and `SpinQuadraticPolynomial`. Achieving a similar
-  behaviour will be done by setting `domain="spin"` when creating a
-  polynomial.
+  `SpinPolynomial` and `SpinQuadraticPolynomial` will be removed in
+  simulated-bifurcation 1.3.0. From version 1.3.0 onwards, polynomials will
+  no longer have a definition domain. The domain only needs to be specified
+  when creating an Ising model, and conversely when converting spins back
+  into the original domain.
 
 Multivariate degree 2 polynomials are the sum of a quadratic form and a
 linear form plus a constant term:
@@ -57,9 +59,11 @@ class SpinQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
     Multivariate degree 2 polynomials over spin vectors.
 
     .. deprecated:: 1.2.1
-        `SpinQuadraticPolynomial` will be removed in simulated-bifurcation
-        1.3.0. Achieving a similar behaviour will be done by setting
-        `domain="spin"` when creating a polynomial.
+      `SpinQuadraticPolynomial` will be removed in simulated-bifurcation
+      1.3.0. From version 1.3.0 onwards, polynomials will no longer have a
+      definition domain. The domain only needs to be specified when
+      creating an Ising model, and conversely when converting spins back
+      into the original domain.
 
     Multivariate degree 2 polynomials are the sum of a quadratic form and a
     linear form plus a constant term:
@@ -142,8 +146,10 @@ class SpinQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
             warnings.warn(
                 "`SpinQuadraticPolynomial` is deprecated as of simulated-bifurcation "
                 "1.2.1, and it will be removed in simulated-bifurcation 1.3.0. "
-                "Achieving a similar behaviour will be done by setting "
-                '`domain="spin"` when creating a polynomial.',
+                "From version 1.3.0 onwards, polynomials will no longer have a "
+                "definition domain. The domain only needs to be specified when "
+                "creating an Ising model, and conversely when converting spins "
+                "back into the original domain.",
                 DeprecationWarning,
                 stacklevel=3,
             )
@@ -184,9 +190,11 @@ class SpinPolynomial(SpinQuadraticPolynomial):
 
     """
     .. deprecated:: 1.2.1
-        `SpinPolynomial` will be removed in simulated-bifurcation 1.3.0.
-        Achieving a similar behaviour will be done by setting
-        `domain="spin"` when creating a polynomial.
+      `SpinPolynomial` will be removed in simulated-bifurcation 1.3.0. From
+      version 1.3.0 onwards, polynomials will no longer have a definition
+      domain. The domain only needs to be specified when creating an Ising
+      model, and conversely when converting spins back into the original
+      domain.
 
     """
 
@@ -194,9 +202,10 @@ class SpinPolynomial(SpinQuadraticPolynomial):
         # 2023-10-03, 1.2.1
         warnings.warn(
             "`SpinPolynomial` is deprecated as of simulated-bifurcation 1.2.1, and "
-            "it will be removed in simulated-bifurcation 1.3.0. Achieving a similar "
-            'behaviour will be done by setting `domain="spin"` when creating a '
-            "polynomial.",
+            "it will be removed in simulated-bifurcation 1.3.0. From version 1.3.0 "
+            "onwards, polynomials will no longer have a definition domain. The domain "
+            "only needs to be specified when creating an Ising model, and conversely "
+            "when converting spins back into the original domain.",
             DeprecationWarning,
             stacklevel=3,
         )

--- a/src/simulated_bifurcation/polynomial/spin_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/spin_polynomial.py
@@ -148,7 +148,15 @@ class SpinQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
                 stacklevel=3,
             )
 
-        super().__init__(matrix, vector, constant, [-1, 1], dtype, device)
+        super().__init__(
+            matrix,
+            vector,
+            constant,
+            [-1, 1],
+            dtype,
+            device,
+            silence_deprecation_warning=True,
+        )
 
     def to_ising(self) -> IsingCore:
         return IsingCore(-2 * self.matrix, self.vector, self.dtype, self.device)

--- a/src/simulated_bifurcation/polynomial/spin_polynomial.py
+++ b/src/simulated_bifurcation/polynomial/spin_polynomial.py
@@ -2,9 +2,9 @@
 Implementation of multivariate degree 2 polynomials over spin vectors.
 
 .. deprecated:: 1.2.1
-    `SpinPolynomial` will be modified in simulated-bifurcation 1.3.0, it is
-    replaced by `SpinQuadraticPolynomial` in prevision of the addition of
-    multivariate polynomials of an arbitrary degree.
+  `SpinPolynomial` and `SpinQuadraticPolynomial`. Achieving a similar
+  behaviour will be done by setting `domain="spin"` when creating a
+  polynomial.
 
 Multivariate degree 2 polynomials are the sum of a quadratic form and a
 linear form plus a constant term:
@@ -55,6 +55,11 @@ class SpinQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
 
     """
     Multivariate degree 2 polynomials over spin vectors.
+
+    .. deprecated:: 1.2.1
+        `SpinQuadraticPolynomial` will be removed in simulated-bifurcation
+        1.3.0. Achieving a similar behaviour will be done by setting
+        `domain="spin"` when creating a polynomial.
 
     Multivariate degree 2 polynomials are the sum of a quadratic form and a
     linear form plus a constant term:
@@ -129,7 +134,20 @@ class SpinQuadraticPolynomial(BaseMultivariateQuadraticPolynomial):
         constant: Union[float, int, None] = None,
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
+        *,
+        silence_deprecation_warning=False,
     ) -> None:
+        if not silence_deprecation_warning:
+            # 2023-11-21, 1.2.1
+            warnings.warn(
+                "`SpinQuadraticPolynomial` is deprecated as of simulated-bifurcation "
+                "1.2.1, and it will be removed in simulated-bifurcation 1.3.0. "
+                "Achieving a similar behaviour will be done by setting "
+                '`domain="spin"` when creating a polynomial.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+
         super().__init__(matrix, vector, constant, [-1, 1], dtype, device)
 
     def to_ising(self) -> IsingCore:
@@ -158,9 +176,9 @@ class SpinPolynomial(SpinQuadraticPolynomial):
 
     """
     .. deprecated:: 1.2.1
-        `SpinPolynomial` will be modified in simulated-bifurcation 1.3.0,
-        it is replaced by `SpinQuadraticPolynomial` in prevision of the
-        addition of multivariate polynomials of an arbitrary degree.
+        `SpinPolynomial` will be removed in simulated-bifurcation 1.3.0.
+        Achieving a similar behaviour will be done by setting
+        `domain="spin"` when creating a polynomial.
 
     """
 
@@ -168,9 +186,10 @@ class SpinPolynomial(SpinQuadraticPolynomial):
         # 2023-10-03, 1.2.1
         warnings.warn(
             "`SpinPolynomial` is deprecated as of simulated-bifurcation 1.2.1, and "
-            "its behaviour will change in simulated-bifurcation 1.3.0. Please use "
-            "`SpinQuadraticPolynomial` instead.",
+            "it will be removed in simulated-bifurcation 1.3.0. Achieving a similar "
+            'behaviour will be done by setting `domain="spin"` when creating a '
+            "polynomial.",
             DeprecationWarning,
             stacklevel=3,
         )
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs, silence_deprecation_warning=True)

--- a/src/simulated_bifurcation/simulated_bifurcation.py
+++ b/src/simulated_bifurcation/simulated_bifurcation.py
@@ -23,6 +23,7 @@ models:
 
 
 import re
+import warnings
 from typing import Optional, Tuple, Union
 
 import torch
@@ -40,7 +41,7 @@ def optimize(
     matrix: Union[torch.Tensor, ndarray],
     vector: Union[torch.Tensor, ndarray, None] = None,
     constant: Union[int, float, None] = None,
-    input_type: str = "spin",
+    domain: str = "spin",
     dtype: Optional[torch.dtype] = None,
     device: Optional[Union[str, torch.device]] = None,
     agents: int = 128,
@@ -55,6 +56,7 @@ def optimize(
     sampling_period: int = 50,
     convergence_threshold: int = 50,
     timeout: Optional[float] = None,
+    input_type: Optional[str] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Optimize a multivariate degree 2 polynomial using the SB algorithm.
@@ -62,7 +64,7 @@ def optimize(
     The simulated bifurcated (SB) algorithm is a randomized approximation
     algorithm for combinatorial optimization problems.
     The optimization can either be a minimization or a maximization, and
-    it is done over a discrete domain specified through `input_type`.
+    it is done over a discrete domain specified through `domain`.
     The polynomial is the sum of a quadratic form and a linear form plus
     a constant term:
     `ΣΣ Q(i,j)x(i)x(j) + Σ l(i)x(i) + c`
@@ -82,7 +84,7 @@ def optimize(
     constant : int | float | None, optional
         Constant of the polynomial. The default is None which signifies
         there is no constant term, that is `constant` = 0.
-    input_type : {"spin", "binary", "int..."}, default="spin"
+    domain : {"spin", "binary", "int..."}, default="spin"
         Domain over which the optimization is done.
         • "spin" : Optimize the polynomial over vectors whose entries are
         in {-1, 1}.
@@ -124,6 +126,7 @@ def optimize(
     verbose : bool, default=True
         Whether to display a progress bar to monitor the progress of the
         algorithm.
+    input_type : deprecated, use `domain` instead.
 
     Returns
     -------
@@ -159,7 +162,7 @@ def optimize(
     Raises
     ------
     ValueError
-        If `input_type` is not one of {"spin", "binary", "int..."}, where
+        If `domain` is not one of {"spin", "binary", "int..."}, where
         "int..." designates any string starting with "int" and followed by
         a positive integer, or more formally, any string matching the
         following regular expression: ^int[1-9][0-9]*$.
@@ -248,7 +251,7 @@ def optimize(
     >>> Q = torch.tensor([[1, -2],
     ...                   [0, 3]])
     >>> best_vector, best_value = sb.optimize(
-    ...     Q, minimize=False, input_type="binary"
+    ...     Q, minimize=False, domain="binary"
     ... )
     >>> best_vector
     tensor([0., 1.])
@@ -258,7 +261,7 @@ def optimize(
     Minimize a polynomial over {-1, 1} x {-1, 1} and return all the
     solutions found using 42 agents
     >>> best_vectors, best_values = sb.optimize(
-    ...     Q, input_type="spin", agents=42, best_only=False
+    ...     Q, domain="spin", agents=42, best_only=False
     ... )
     >>> best_vectors.shape  # (agents, dimension of the instance)
     (42, 2)
@@ -268,7 +271,7 @@ def optimize(
     Minimize a polynomial over {0, 1, 2, ..., 6, 7} x {0, 1, 2, ..., 6, 7}
     using the GPU to run the SB algorithm. Outputs are located on the GPU.
     >>> best_vector, best_value = sb.optimize(
-    ...     Q, input_type="int3", device="cuda"
+    ...     Q, domain="int3", device="cuda"
     ... )
     >>> best_vector
     tensor([0., 0.], device='cuda:0')
@@ -276,11 +279,21 @@ def optimize(
     tensor(0., device='cuda:0')
 
     """
+    if input_type is not None:
+        # 2023-11-21, 1.2.1
+        warnings.warn(
+            "`input_type` is deprecated as of simulated-bifurcation 1.2.1, and it will "
+            "be removed in simulated-bifurcation 1.3.0. Please use `domain` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        domain = input_type
+
     model = build_model(
         matrix=matrix,
         vector=vector,
         constant=constant,
-        input_type=input_type,
+        domain=domain,
         dtype=dtype,
         device=device,
     )
@@ -304,7 +317,7 @@ def minimize(
     matrix: Union[torch.Tensor, ndarray],
     vector: Union[torch.Tensor, ndarray, None] = None,
     constant: Union[int, float, None] = None,
-    input_type: str = "spin",
+    domain: str = "spin",
     dtype: Optional[torch.dtype] = None,
     device: Optional[Union[str, torch.device]] = None,
     agents: int = 128,
@@ -318,6 +331,7 @@ def minimize(
     sampling_period: int = 50,
     convergence_threshold: int = 50,
     timeout: Optional[float] = None,
+    input_type: Optional[str] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Minimize a multivariate degree 2 polynomial using the SB algorithm.
@@ -325,7 +339,7 @@ def minimize(
     The simulated bifurcated (SB) algorithm is a randomized approximation
     algorithm for combinatorial optimization problems.
     The minimization is done over a discrete domain specified through
-    `input_type`.
+    `domain`.
     The polynomial is the sum of a quadratic form and a linear form plus
     a constant term:
     `ΣΣ Q(i,j)x(i)x(j) + Σ l(i)x(i) + c`
@@ -345,7 +359,7 @@ def minimize(
     constant : int | float | None, optional
         Constant of the polynomial. The default is None which signifies
         there is no constant term, that is `constant` = 0.
-    input_type : {"spin", "binary", "int..."}, default="spin"
+    domain : {"spin", "binary", "int..."}, default="spin"
         Domain over which the minimization is done.
         • "spin" : Minimize the polynomial over vectors whose entries are
         in {-1, 1}.
@@ -384,6 +398,7 @@ def minimize(
     verbose : bool, default=True
         Whether to display a progress bar to monitor the progress of the
         algorithm.
+    input_type : deprecated, use `domain` instead.
 
     Returns
     -------
@@ -419,7 +434,7 @@ def minimize(
     Raises
     ------
     ValueError
-        If `input_type` is not one of {"spin", "binary", "int..."}, where
+        If `domain` is not one of {"spin", "binary", "int..."}, where
         "int..." designates any string starting with "int" and followed by
         a positive integer, or more formally, any string matching the
         following regular expression: ^int[1-9][0-9]*$.
@@ -506,7 +521,7 @@ def minimize(
     Minimize a polynomial over {0, 1} x {0, 1}
     >>> Q = torch.tensor([[1, -2],
     ...                   [0, 3]])
-    >>> best_vector, best_value = sb.minimize(Q, input_type="binary")
+    >>> best_vector, best_value = sb.minimize(Q, domain="binary")
     >>> best_vector
     tensor([0., 0.])
     >>> best_value
@@ -514,7 +529,7 @@ def minimize(
 
     Return all the solutions found using 42 agents
     >>> best_vectors, best_values = sb.minimize(
-    ...     Q, input_type="binary", agents=42, best_only=False
+    ...     Q, domain="binary", agents=42, best_only=False
     ... )
     >>> best_vectors.shape  # (agents, dimension of the instance)
     (42, 2)
@@ -524,7 +539,7 @@ def minimize(
     Minimize a polynomial over {0, 1, 2, ..., 6, 7} x {0, 1, 2, ..., 6, 7}
     using the GPU to run the SB algorithm. Outputs are located on the GPU.
     >>> best_vector, best_value = sb.minimize(
-    ...     Q, input_type="int3", device="cuda"
+    ...     Q, domain="int3", device="cuda"
     ... )
     >>> best_vector
     tensor([0., 0.], device='cuda:0')
@@ -532,11 +547,21 @@ def minimize(
     tensor(0., device='cuda:0')
 
     """
+    if input_type is not None:
+        # 2023-11-21, 1.2.1
+        warnings.warn(
+            "`input_type` is deprecated as of simulated-bifurcation 1.2.1, and it will "
+            "be removed in simulated-bifurcation 1.3.0. Please use `domain` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        domain = input_type
+
     return optimize(
         matrix,
         vector,
         constant,
-        input_type,
+        domain,
         dtype,
         device,
         agents,
@@ -557,7 +582,7 @@ def maximize(
     matrix: Union[torch.Tensor, ndarray],
     vector: Union[torch.Tensor, ndarray, None] = None,
     constant: Union[int, float, None] = None,
-    input_type: str = "spin",
+    domain: str = "spin",
     dtype: Optional[torch.dtype] = None,
     device: Optional[Union[str, torch.device]] = None,
     agents: int = 128,
@@ -571,6 +596,7 @@ def maximize(
     sampling_period: int = 50,
     convergence_threshold: int = 50,
     timeout: Optional[float] = None,
+    input_type: Optional[str] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Maximize a multivariate degree 2 polynomial using the SB algorithm.
@@ -578,7 +604,7 @@ def maximize(
     The simulated bifurcated (SB) algorithm is a randomized approximation
     algorithm for combinatorial optimization problems.
     The maximization is done over a discrete domain specified through
-    `input_type`.
+    `domain`.
     The polynomial is the sum of a quadratic form and a linear form plus
     a constant term:
     `ΣΣ Q(i,j)x(i)x(j) + Σ l(i)x(i) + c`
@@ -598,7 +624,7 @@ def maximize(
     constant : int | float | None, optional
         Constant of the polynomial. The default is None which signifies
         there is no constant term, that is `constant` = 0.
-    input_type : {"spin", "binary", "int..."}, default="spin"
+    domain : {"spin", "binary", "int..."}, default="spin"
         Domain over which the maximization is done.
         • "spin" : Maximize the polynomial over vectors whose entries are
         in {-1, 1}.
@@ -637,6 +663,7 @@ def maximize(
     verbose : bool, default=True
         Whether to display a progress bar to monitor the progress of the
         algorithm.
+    input_type : deprecated, use `domain` instead.
 
     Returns
     -------
@@ -672,7 +699,7 @@ def maximize(
     Raises
     ------
     ValueError
-        If `input_type` is not one of {"spin", "binary", "int..."}, where
+        If `domain` is not one of {"spin", "binary", "int..."}, where
         "int..." designates any string starting with "int" and followed by
         a positive integer, or more formally, any string matching the
         following regular expression: ^int[1-9][0-9]*$.
@@ -759,7 +786,7 @@ def maximize(
     Maximize a polynomial over {0, 1} x {0, 1}
     >>> Q = torch.tensor([[1, -2],
     ...                   [0, 3]])
-    >>> best_vector, best_value = sb.maximize(Q, input_type="binary")
+    >>> best_vector, best_value = sb.maximize(Q, domain="binary")
     >>> best_vector
     tensor([0., 1.])
     >>> best_value
@@ -767,7 +794,7 @@ def maximize(
 
     Return all the solutions found using 42 agents
     >>> best_vectors, best_values = sb.maximize(
-    ...     Q, input_type="binary", agents=42, best_only=False
+    ...     Q, domain="binary", agents=42, best_only=False
     ... )
     >>> best_vectors.shape  # (agents, dimension of the instance)
     (42, 2)
@@ -777,7 +804,7 @@ def maximize(
     Maximize a polynomial over {0, 1, 2, ..., 6, 7} x {0, 1, 2, ..., 6, 7}
     using the GPU to run the SB algorithm. Outputs are located on the GPU.
     >>> best_vector, best_value = sb.maximize(
-    ...     Q, input_type="int3", device="cuda"
+    ...     Q, domain="int3", device="cuda"
     ... )
     >>> best_vector
     tensor([0., 7.], device='cuda:0')
@@ -785,11 +812,21 @@ def maximize(
     tensor(147., device='cuda:0')
 
     """
+    if input_type is not None:
+        # 2023-11-21, 1.2.1
+        warnings.warn(
+            "`input_type` is deprecated as of simulated-bifurcation 1.2.1, and it will "
+            "be removed in simulated-bifurcation 1.3.0. Please use `domain` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        domain = input_type
+
     return optimize(
         matrix,
         vector,
         constant,
-        input_type,
+        domain,
         dtype,
         device,
         agents,
@@ -810,9 +847,10 @@ def build_model(
     matrix: Union[torch.Tensor, ndarray],
     vector: Union[torch.Tensor, ndarray, None] = None,
     constant: Union[int, float, None] = None,
-    input_type: str = "spin",
+    domain: str = "spin",
     dtype: Optional[torch.dtype] = None,
     device: Optional[Union[str, torch.device]] = None,
+    input_type: Optional[str] = None,
 ) -> BaseMultivariateQuadraticPolynomial:
     """
     Instantiate a multivariate degree 2 polynomial over a given domain.
@@ -836,7 +874,7 @@ def build_model(
     constant : int | float | None, optional
         Constant of the polynomial. The default is None which signifies
         there is no constant term, that is `constant` = 0.
-    input_type : {"spin", "binary", "int..."}, default="spin"
+    domain : {"spin", "binary", "int..."}, default="spin"
         Domain over which the maximization is done.
         - "spin" : Polynomial over vectors whose entries are in {-1, 1}.
         - "binary" : Polynomial over vectors whose entries are in {0, 1}.
@@ -849,20 +887,21 @@ def build_model(
     device : str | torch.device, default="cpu"
         Device on which the polynomial is located. If available, use "cuda"
         to use the polynomial on a GPU.
+    input_type : deprecated, use `domain` instead.
 
     Returns
     -------
     SpinQuadraticPolynomial | BinaryQuadraticPolynomial | IntegerQuadraticPolynomial
         The polynomial described by `matrix`, `vector` and `constant` on
-        the domain specified by `input_type`.
-        - `input_type="spin"` : SpinQuadraticPolynomial.
-        - `input_type="binary"` : BinaryQuadraticPolynomial.
-        - `input_type="int..."` : IntegerQuadraticPolynomial.
+        the domain specified by `domain`.
+        - `domain="spin"` : SpinQuadraticPolynomial.
+        - `domain="binary"` : BinaryQuadraticPolynomial.
+        - `domain="int..."` : IntegerQuadraticPolynomial.
 
     Raises
     ------
     ValueError
-        If `input_type` is not one of {"spin", "binary", "int..."}, where
+        If `domain` is not one of {"spin", "binary", "int..."}, where
         "int..." designates any string starting with "int" and followed by
         a positive integer, or more formally, any string matching the
         following regular expression: ^int[1-9][0-9]*$.
@@ -889,7 +928,7 @@ def build_model(
     Instantiate a polynomial over {0, 1} x {0, 1}
     >>> Q = torch.tensor([[1, -2],
     ...                   [0, 3]])
-    >>> poly = sb.build_model(Q, input_type="binary")
+    >>> poly = sb.build_model(Q, domain="binary")
 
     Maximize the polynomial
     >>> best_vector, best_value = poly.maximize()
@@ -924,7 +963,7 @@ def build_model(
     and use it on the GPU
     >>> Q = torch.tensor([[1, -2],
     ...                   [0, 3]])
-    >>> poly = sb.build_model(Q, input_type="int4", device="cuda")
+    >>> poly = sb.build_model(Q, domain="int4", device="cuda")
 
     Maximize this polynomial (outputs are located on the GPU)
     >>> best_vector, best_value = poly.maximize()
@@ -940,18 +979,28 @@ def build_model(
     tensor(123., device='cuda:0')
 
     """
+    if input_type is not None:
+        # 2023-11-21, 1.2.1
+        warnings.warn(
+            "`input_type` is deprecated as of simulated-bifurcation 1.2.1, and it will "
+            "be removed in simulated-bifurcation 1.3.0. Please use `domain` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        domain = input_type
+
     int_type_regex = "^int[1-9][0-9]*$"
     int_type_pattern = re.compile(int_type_regex)
 
-    if input_type == "spin":
+    if domain == "spin":
         return SpinQuadraticPolynomial(
             matrix=matrix, vector=vector, constant=constant, dtype=dtype, device=device
         )
-    if input_type == "binary":
+    if domain == "binary":
         return BinaryQuadraticPolynomial(
             matrix=matrix, vector=vector, constant=constant, dtype=dtype, device=device
         )
-    if int_type_pattern.match(input_type) is None:
+    if int_type_pattern.match(domain) is None:
         raise ValueError(
             f'Input type must be one of "spin" or "binary", or be a string starting'
             f'with "int" and be followed by a positive integer.\n'
@@ -959,7 +1008,7 @@ def build_model(
             f"{int_type_regex}\n"
             f'Examples: "int7", "int42", ...'
         )
-    number_of_bits = int(input_type[3:])
+    number_of_bits = int(domain[3:])
     return IntegerQuadraticPolynomial(
         matrix=matrix,
         vector=vector,

--- a/src/simulated_bifurcation/simulated_bifurcation.py
+++ b/src/simulated_bifurcation/simulated_bifurcation.py
@@ -1052,7 +1052,12 @@ def build_model(
         )
     if domain == "binary":
         return BinaryQuadraticPolynomial(
-            matrix=matrix, vector=vector, constant=constant, dtype=dtype, device=device
+            matrix=matrix,
+            vector=vector,
+            constant=constant,
+            dtype=dtype,
+            device=device,
+            silence_deprecation_warning=True,
         )
     if int_type_pattern.match(domain) is None:
         raise ValueError(

--- a/src/simulated_bifurcation/simulated_bifurcation.py
+++ b/src/simulated_bifurcation/simulated_bifurcation.py
@@ -1070,4 +1070,5 @@ def build_model(
         dtype=dtype,
         device=device,
         number_of_bits=number_of_bits,
+        silence_deprecation_warning=True,
     )

--- a/src/simulated_bifurcation/simulated_bifurcation.py
+++ b/src/simulated_bifurcation/simulated_bifurcation.py
@@ -13,6 +13,15 @@ maximize:
 build_model:
     Instantiate a multivariate degree 2 polynomial over a given domain.
 
+.. deprecated:: 1.2.1
+    The functions `sb.optimize`, `sb.minimize`, and `sb.maximize` will be
+    modified in simulated-bifurcation 1.3.0. The `matrix`, `vector`, and
+    `constant` parameters will become positional-only parameters; the other
+    parameters will become keyword-only parameters.
+
+    In simulated-bifurcation 1.3.0, parameters `input_type` will be
+    removed. Use `domain` instead.
+
 See Also
 --------
 models:
@@ -34,6 +43,14 @@ from .polynomial import (
     BinaryQuadraticPolynomial,
     IntegerQuadraticPolynomial,
     SpinQuadraticPolynomial,
+)
+
+warnings.warn(
+    "The functions `sb.optimize`, `sb.minimize`, and `sb.maximize` will be "
+    "modified in simulated-bifurcation 1.3.0. The `matrix`, `vector`, and"
+    "`constant` parameters will become positional-only parameters; the other"
+    "parameters will become keyword-only parameters.",
+    DeprecationWarning,
 )
 
 
@@ -60,6 +77,14 @@ def optimize(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Optimize a multivariate degree 2 polynomial using the SB algorithm.
+
+    .. deprecated:: 1.2.1
+      In simulated-bifurcation 1.3.0, `input_type` will be removed.
+      Use `domain` instead.
+
+      In simulated-bifurcation 1.3.0, the `matrix`, `vector`, and
+      `constant` will become positional-only parameters; the other
+      parameters will become keyword-only parameters.
 
     The simulated bifurcated (SB) algorithm is a randomized approximation
     algorithm for combinatorial optimization problems.
@@ -336,6 +361,14 @@ def minimize(
     """
     Minimize a multivariate degree 2 polynomial using the SB algorithm.
 
+    .. deprecated:: 1.2.1
+      In simulated-bifurcation 1.3.0, `input_type` will be removed.
+      Use `domain` instead.
+
+      In simulated-bifurcation 1.3.0, the `matrix`, `vector`, and
+      `constant` will become positional-only parameters; the other
+      parameters will become keyword-only parameters.
+
     The simulated bifurcated (SB) algorithm is a randomized approximation
     algorithm for combinatorial optimization problems.
     The minimization is done over a discrete domain specified through
@@ -601,6 +634,14 @@ def maximize(
     """
     Maximize a multivariate degree 2 polynomial using the SB algorithm.
 
+    .. deprecated:: 1.2.1
+      In simulated-bifurcation 1.3.0, `input_type` will be removed.
+      Use `domain` instead.
+
+      In simulated-bifurcation 1.3.0, the `matrix`, `vector`, and
+      `constant` will become positional-only parameters; the other
+      parameters will become keyword-only parameters.
+
     The simulated bifurcated (SB) algorithm is a randomized approximation
     algorithm for combinatorial optimization problems.
     The maximization is done over a discrete domain specified through
@@ -854,6 +895,14 @@ def build_model(
 ) -> BaseMultivariateQuadraticPolynomial:
     """
     Instantiate a multivariate degree 2 polynomial over a given domain.
+
+    .. deprecated:: 1.2.1
+      In simulated-bifurcation 1.3.0, `input_type` will be removed.
+      Use `domain` instead.
+
+      In simulated-bifurcation 1.3.0, the `matrix`, `vector`, and
+      `constant` will become positional-only parameters; the other
+      parameters will become keyword-only parameters.
 
     The polynomial is the sum of a quadratic form and a linear form plus
     a constant term:

--- a/src/simulated_bifurcation/simulated_bifurcation.py
+++ b/src/simulated_bifurcation/simulated_bifurcation.py
@@ -1043,7 +1043,12 @@ def build_model(
 
     if domain == "spin":
         return SpinQuadraticPolynomial(
-            matrix=matrix, vector=vector, constant=constant, dtype=dtype, device=device
+            matrix=matrix,
+            vector=vector,
+            constant=constant,
+            dtype=dtype,
+            device=device,
+            silence_deprecation_warning=True,
         )
     if domain == "binary":
         return BinaryQuadraticPolynomial(

--- a/tests/test_binary_polynomial.py
+++ b/tests/test_binary_polynomial.py
@@ -77,4 +77,6 @@ def test_optimize_binary_polynomial():
 
 def test_deprecation_warning():
     with pytest.warns(DeprecationWarning):
+        BinaryQuadraticPolynomial(matrix, vector, constant)
+    with pytest.warns(DeprecationWarning):
         BinaryPolynomial(matrix, vector, constant)

--- a/tests/test_binary_polynomial.py
+++ b/tests/test_binary_polynomial.py
@@ -19,7 +19,9 @@ constant = 1
 
 
 def test_init_binary_polynomial():
-    binary_polynomial = BinaryQuadraticPolynomial(matrix, vector, constant)
+    binary_polynomial = BinaryQuadraticPolynomial(
+        matrix, vector, constant, silence_deprecation_warning=True
+    )
     ising = binary_polynomial.to_ising()
     assert binary_polynomial.convert_spins(ising) is None
     ising.computed_spins = torch.tensor(
@@ -56,14 +58,18 @@ def test_init_binary_polynomial():
 
 
 def test_call_binary_polynomial():
-    binary_polynomial = BinaryQuadraticPolynomial(matrix, vector, constant)
+    binary_polynomial = BinaryQuadraticPolynomial(
+        matrix, vector, constant, silence_deprecation_warning=True
+    )
     assert binary_polynomial(torch.tensor([1, 0, 1], dtype=torch.float32)) == -3
     with pytest.raises(ValueError):
         binary_polynomial(torch.tensor([1, 2, 3], dtype=torch.float32))
 
 
 def test_optimize_binary_polynomial():
-    binary_polynomial = BinaryQuadraticPolynomial(matrix, vector, constant)
+    binary_polynomial = BinaryQuadraticPolynomial(
+        matrix, vector, constant, silence_deprecation_warning=True
+    )
     binary_vars, value = binary_polynomial.optimize(verbose=False)
     assert torch.equal(binary_vars, torch.tensor([1, 0, 1], dtype=torch.float32))
     assert value == -3.0

--- a/tests/test_integer_polynomial.py
+++ b/tests/test_integer_polynomial.py
@@ -20,11 +20,17 @@ constant = 1
 
 def test_init_integer_polynomial():
     with pytest.raises(ValueError):
-        IntegerQuadraticPolynomial(matrix, vector, constant, 0)
+        IntegerQuadraticPolynomial(
+            matrix, vector, constant, 0, silence_deprecation_warning=True
+        )
     with pytest.raises(ValueError):
         # noinspection PyTypeChecker
-        IntegerQuadraticPolynomial(matrix, vector, constant, 2.5)
-    integer_polynomial = IntegerQuadraticPolynomial(matrix, vector, constant, 2)
+        IntegerQuadraticPolynomial(
+            matrix, vector, constant, 2.5, silence_deprecation_warning=True
+        )
+    integer_polynomial = IntegerQuadraticPolynomial(
+        matrix, vector, constant, 2, silence_deprecation_warning=True
+    )
     ising = integer_polynomial.to_ising()
     assert integer_polynomial.convert_spins(ising) is None
     ising.computed_spins = torch.tensor(
@@ -69,14 +75,18 @@ def test_init_integer_polynomial():
 
 
 def test_call_integer_polynomial():
-    integer_polynomial = IntegerQuadraticPolynomial(matrix, vector, constant, 2)
+    integer_polynomial = IntegerQuadraticPolynomial(
+        matrix, vector, constant, 2, silence_deprecation_warning=True
+    )
     assert integer_polynomial(torch.tensor([2, 3, 0], dtype=torch.float32)) == 21
     with pytest.raises(ValueError):
         integer_polynomial(torch.tensor([1, 2, 8], dtype=torch.float32))
 
 
 def test_optimize_integer_polynomial():
-    integer_polynomial = IntegerQuadraticPolynomial(matrix, vector, constant, 2)
+    integer_polynomial = IntegerQuadraticPolynomial(
+        matrix, vector, constant, 2, silence_deprecation_warning=True
+    )
     int_vars, value = integer_polynomial.optimize(verbose=False)
     assert torch.equal(int_vars, torch.tensor([3, 0, 3], dtype=torch.float32))
     assert value == -23.0

--- a/tests/test_integer_polynomial.py
+++ b/tests/test_integer_polynomial.py
@@ -94,4 +94,6 @@ def test_optimize_integer_polynomial():
 
 def test_deprecation_warning():
     with pytest.warns(DeprecationWarning):
+        IntegerQuadraticPolynomial(matrix, vector, constant)
+    with pytest.warns(DeprecationWarning):
         IntegerPolynomial(matrix, vector, constant)

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -21,9 +21,6 @@ constant = 1
 
 
 class BaseMultivariateQuadraticPolynomialImpl(BaseMultivariateQuadraticPolynomial):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs, silence_deprecation_warning=True)
-
     def to_ising(self):
         pass  # pragma: no cover
 
@@ -40,7 +37,9 @@ class IsingPolynomialInterfaceImpl(IsingPolynomialInterface):
 
 
 def test_init_polynomial_from_tensors():
-    polynomial = BaseMultivariateQuadraticPolynomialImpl(matrix, vector, constant)
+    polynomial = BaseMultivariateQuadraticPolynomialImpl(
+        matrix, vector, constant, silence_deprecation_warning=True
+    )
     assert torch.equal(polynomial.matrix, matrix)
     assert torch.equal(polynomial.vector, vector.reshape(3))
     assert polynomial.constant == 1.0
@@ -58,7 +57,7 @@ def test_init_polynomial_from_tensors():
 
 def test_init_polynomial_from_arrays():
     polynomial = BaseMultivariateQuadraticPolynomialImpl(
-        matrix.numpy(), vector.numpy(), constant
+        matrix.numpy(), vector.numpy(), constant, silence_deprecation_warning=True
     )
     assert torch.equal(polynomial.matrix, matrix)
     assert torch.equal(polynomial.vector, vector.reshape(3))
@@ -71,7 +70,9 @@ def test_init_polynomial_from_arrays():
 
 
 def test_init_polynomial_without_order_one_and_zero():
-    polynomial = BaseMultivariateQuadraticPolynomialImpl(matrix)
+    polynomial = BaseMultivariateQuadraticPolynomialImpl(
+        matrix, silence_deprecation_warning=True
+    )
     assert torch.equal(polynomial.matrix, matrix)
     assert torch.equal(polynomial.vector, torch.zeros(polynomial.dimension))
     assert polynomial.constant == 0.0
@@ -85,9 +86,11 @@ def test_init_polynomial_without_order_one_and_zero():
 def test_init_with_wrong_parameters():
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker
-        BaseMultivariateQuadraticPolynomialImpl(None)
+        BaseMultivariateQuadraticPolynomialImpl(None, silence_deprecation_warning=True)
     with pytest.raises(ValueError):
-        BaseMultivariateQuadraticPolynomialImpl(torch.unsqueeze(matrix, 0))
+        BaseMultivariateQuadraticPolynomialImpl(
+            torch.unsqueeze(matrix, 0), silence_deprecation_warning=True
+        )
     with pytest.raises(ValueError):
         BaseMultivariateQuadraticPolynomialImpl(
             torch.tensor(
@@ -96,33 +99,50 @@ def test_init_with_wrong_parameters():
                     [4, 5, 6],
                 ],
                 dtype=torch.float32,
-            )
+            ),
+            silence_deprecation_warning=True,
         )
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker
-        BaseMultivariateQuadraticPolynomialImpl(matrix, ("hello", "world!"))
+        BaseMultivariateQuadraticPolynomialImpl(
+            matrix, ("hello", "world!"), silence_deprecation_warning=True
+        )
     with pytest.raises(ValueError):
         # noinspection PyTypeChecker
-        BaseMultivariateQuadraticPolynomialImpl(matrix, 1)
+        BaseMultivariateQuadraticPolynomialImpl(
+            matrix, 1, silence_deprecation_warning=True
+        )
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker
-        BaseMultivariateQuadraticPolynomialImpl(matrix, constant="hello world!")
+        BaseMultivariateQuadraticPolynomialImpl(
+            matrix, constant="hello world!", silence_deprecation_warning=True
+        )
 
 
 def test_check_device():
-    BaseMultivariateQuadraticPolynomialImpl(matrix, device="cpu")
+    BaseMultivariateQuadraticPolynomialImpl(
+        matrix, device="cpu", silence_deprecation_warning=True
+    )
     with pytest.raises(TypeError):
         # noinspection PyTypeChecker
-        BaseMultivariateQuadraticPolynomialImpl(matrix, device=1)
+        BaseMultivariateQuadraticPolynomialImpl(
+            matrix, device=1, silence_deprecation_warning=True
+        )
     if not torch.cuda.is_available():  # pragma: no cover
         with pytest.raises(RuntimeError):
-            BaseMultivariateQuadraticPolynomialImpl(matrix, device="cuda")
+            BaseMultivariateQuadraticPolynomialImpl(
+                matrix, device="cuda", silence_deprecation_warning=True
+            )
     else:  # pragma: no cover
-        BaseMultivariateQuadraticPolynomialImpl(matrix, device="cuda")
+        BaseMultivariateQuadraticPolynomialImpl(
+            matrix, device="cuda", silence_deprecation_warning=True
+        )
 
 
 def test_call_polynomial():
-    polynomial = BaseMultivariateQuadraticPolynomialImpl(matrix)
+    polynomial = BaseMultivariateQuadraticPolynomialImpl(
+        matrix, silence_deprecation_warning=True
+    )
     assert polynomial(torch.tensor([0, 0, 0], dtype=torch.float32)) == 0.0
     assert torch.equal(
         polynomial(
@@ -150,7 +170,9 @@ def test_call_polynomial():
 
 
 def test_call_polynomial_with_accepted_values():
-    polynomial = BaseMultivariateQuadraticPolynomialImpl(matrix, accepted_values=[0, 1])
+    polynomial = BaseMultivariateQuadraticPolynomialImpl(
+        matrix, accepted_values=[0, 1], silence_deprecation_warning=True
+    )
     assert polynomial(torch.tensor([0, 0, 0], dtype=torch.float32)) == 0
     with pytest.raises(ValueError):
         polynomial(torch.tensor([0, 1, 2], dtype=torch.float32))
@@ -229,5 +251,7 @@ def test_maximize():
 
 
 def test_deprecation_warning():
+    with pytest.warns(DeprecationWarning):
+        BaseMultivariateQuadraticPolynomialImpl(matrix, accepted_values=[0, 1])
     with pytest.warns(DeprecationWarning):
         IsingPolynomialInterfaceImpl(matrix, accepted_values=[0, 1])

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -21,6 +21,9 @@ constant = 1
 
 
 class BaseMultivariateQuadraticPolynomialImpl(BaseMultivariateQuadraticPolynomial):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, silence_deprecation_warning=True)
+
     def to_ising(self):
         pass  # pragma: no cover
 

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -173,7 +173,7 @@ def test_best_only():
         matrix=matrix,
         vector=vector,
         constant=constant,
-        input_type="spin",
+        domain="spin",
         dtype=torch.float32,
         device="cpu",
     )
@@ -196,7 +196,7 @@ def test_minimize():
         matrix=matrix,
         vector=vector,
         constant=constant,
-        input_type="spin",
+        domain="spin",
         dtype=torch.float32,
         device="cpu",
     )
@@ -214,7 +214,7 @@ def test_maximize():
         matrix=matrix,
         vector=vector,
         constant=constant,
-        input_type="spin",
+        domain="spin",
         dtype=torch.float32,
         device="cpu",
     )

--- a/tests/test_simulated_bifurcation.py
+++ b/tests/test_simulated_bifurcation.py
@@ -53,30 +53,30 @@ def test_maximize_integer():
     assert 37 == best_value
 
 
-def test_valid_input_type():
-    build_model(matrix, input_type="spin")
-    build_model(matrix, input_type="binary")
-    build_model(matrix, input_type="int1")
-    build_model(matrix, input_type="int3")
-    build_model(matrix, input_type="int10")
-    build_model(matrix, input_type="int22")
+def test_valid_domain():
+    build_model(matrix, domain="spin")
+    build_model(matrix, domain="binary")
+    build_model(matrix, domain="int1")
+    build_model(matrix, domain="int3")
+    build_model(matrix, domain="int10")
+    build_model(matrix, domain="int22")
 
 
-def test_invalid_input_type():
+def test_invalid_domain():
     with pytest.raises(ValueError):
-        build_model(matrix, input_type="float")
+        build_model(matrix, domain="float")
     with pytest.raises(ValueError):
-        build_model(matrix, input_type="")
+        build_model(matrix, domain="")
     with pytest.raises(ValueError):
-        build_model(matrix, input_type="int")
+        build_model(matrix, domain="int")
     with pytest.raises(ValueError):
-        build_model(matrix, input_type=" int3")
+        build_model(matrix, domain=" int3")
     with pytest.raises(ValueError):
-        build_model(matrix, input_type="int0")
+        build_model(matrix, domain="int0")
     with pytest.raises(ValueError):
-        build_model(matrix, input_type="int07")
+        build_model(matrix, domain="int07")
     with pytest.raises(ValueError):
-        build_model(matrix, input_type="int5.")
+        build_model(matrix, domain="int5.")
 
 
 def test_best_only():

--- a/tests/test_simulated_bifurcation.py
+++ b/tests/test_simulated_bifurcation.py
@@ -1,7 +1,8 @@
 import pytest
 import torch
 
-from src.simulated_bifurcation import build_model, maximize, minimize
+import src.simulated_bifurcation
+from src.simulated_bifurcation import build_model, maximize, minimize, optimize
 
 matrix = torch.tensor(
     [
@@ -88,3 +89,15 @@ def test_best_only():
     assert spins_all.shape == (42, 3)
     assert isinstance(energies_all, torch.Tensor)
     assert energies_all.shape == (42,)
+
+
+def test_input_type_deprecation():
+    with pytest.warns(DeprecationWarning):
+        optimize(matrix, vector, constant, input_type="int7")
+    with pytest.warns(DeprecationWarning):
+        minimize(matrix, vector, constant, input_type="spin")
+    with pytest.warns(DeprecationWarning):
+        maximize(matrix, vector, constant, input_type="binary")
+    with pytest.warns(DeprecationWarning):
+        model = build_model(matrix, vector, constant, input_type="int3")
+    assert isinstance(model, src.simulated_bifurcation.IntegerQuadraticPolynomial)

--- a/tests/test_spin_polynomial.py
+++ b/tests/test_spin_polynomial.py
@@ -16,7 +16,9 @@ constant = 1
 
 
 def test_init_spin_polynomial():
-    spin_polynomial = SpinQuadraticPolynomial(matrix, vector, constant)
+    spin_polynomial = SpinQuadraticPolynomial(
+        matrix, vector, constant, silence_deprecation_warning=True
+    )
     ising = spin_polynomial.to_ising()
     ising.computed_spins = torch.tensor(
         [
@@ -52,21 +54,27 @@ def test_init_spin_polynomial():
 
 
 def test_call_spin_polynomial():
-    spin_polynomial = SpinQuadraticPolynomial(matrix, vector, constant)
+    spin_polynomial = SpinQuadraticPolynomial(
+        matrix, vector, constant, silence_deprecation_warning=True
+    )
     assert spin_polynomial(torch.tensor([1, -1, 1], dtype=torch.float32)) == -11
     with pytest.raises(ValueError):
         spin_polynomial(torch.tensor([1, 2, 3], dtype=torch.float32))
 
 
 def test_optimize_spin_polynomial():
-    spin_polynomial = SpinQuadraticPolynomial(matrix, vector, constant)
+    spin_polynomial = SpinQuadraticPolynomial(
+        matrix, vector, constant, silence_deprecation_warning=True
+    )
     spin_vars, value = spin_polynomial.optimize(verbose=False)
     assert torch.equal(spin_vars, torch.tensor([1, -1, 1], dtype=torch.float32))
     assert value == -11.0
 
 
 def test_to():
-    spin_polynomial = SpinQuadraticPolynomial(matrix, vector, constant)
+    spin_polynomial = SpinQuadraticPolynomial(
+        matrix, vector, constant, silence_deprecation_warning=True
+    )
 
     def check_device_and_dtype(dtype: torch.dtype):
         assert spin_polynomial.dtype == dtype

--- a/tests/test_spin_polynomial.py
+++ b/tests/test_spin_polynomial.py
@@ -103,4 +103,6 @@ def test_to():
 
 def test_deprecation_warning():
     with pytest.warns(DeprecationWarning):
+        SpinQuadraticPolynomial(matrix, vector, constant)
+    with pytest.warns(DeprecationWarning):
         SpinPolynomial(matrix, vector, constant)


### PR DESCRIPTION
# 💬 Pull Request Description

This pull request includes version changes for the v1.2.1 release and introduces deprecation warnings in preparation for version 1.3.0.

# ✔️ Check list

- [x] The code matches the styling rules.
- [x] The new code is covered by relevant tests.
- [x] Documentation was added.

# 🚀 New features

## Deprecation of the `input_type` parameter

In the functions `sb.optimize`, `sb.minimize`, and `sb.maximize`, the `input_type` parameter is now deprecated and will be removed in version 1.3.0. Please use the `domain` parameter instead.

## Deprecation of the instantiation of the polynomial classes

The instantiation of the following classes is deprecated due to non-backwards compatible changes planned for version 1.3.0. Their usage should not change, except for instantiation. If needed, they all accept a `silence_deprecation_warning` keyword-only parameter (default is `False`).

- BinaryQuadraticPolynomial
- IntegerQuadraticPolynomial
- SpinQuadraticPolynomial
- BaseMultivariateQuadraticPolynomial

## Deprecation of the old polynomial classes

The following polynomial classes are deprecated. Please use the equivalent classes mentioned above.

- BinaryPolynomial
- IntegerPolynomial
- SpinPolynomial
- IsingPolynomialInterface

# 🐞 Bug fixes

None

# 📣 Supplementary information

None
