### PR TITLE
Force backend dtype to float

### DIFF
--- a/src/simulated_bifurcation/check_dtype.py
+++ b/src/simulated_bifurcation/check_dtype.py
@@ -1,0 +1,13 @@
+from typing import Optional
+
+import torch
+
+
+def check_dtype(dtype: Optional[torch.dtype]) -> torch.dtype:
+    if dtype is None:
+        return torch.float32
+    if dtype not in [torch.float32, torch.float64]:
+        raise ValueError(
+            "Only torch.float32 and torch.float64 are accepted for Simulated Bifurcation computations."
+        )
+    return dtype

--- a/src/simulated_bifurcation/core/ising.py
+++ b/src/simulated_bifurcation/core/ising.py
@@ -23,6 +23,7 @@ from typing import Optional, TypeVar, Union
 import torch
 from numpy import ndarray
 
+from ..check_dtype import check_dtype
 from ..optimizer import SimulatedBifurcationEngine, SimulatedBifurcationOptimizer
 
 # Workaround because `Self` type is only available in Python >= 3.11
@@ -91,6 +92,7 @@ class Ising:
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
     ) -> None:
+        dtype = check_dtype(dtype)
         self.dimension = J.shape[0]
         if isinstance(J, ndarray):
             J = torch.from_numpy(J)

--- a/src/simulated_bifurcation/models/ising.py
+++ b/src/simulated_bifurcation/models/ising.py
@@ -25,6 +25,9 @@ class Ising(ABCModel):
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
     ) -> None:
-        super().__init__(-0.5 * J, h, dtype=dtype, device=device)
-        self.J = J
-        self.h = h
+        _tensors = (-0.5 * J,)
+        if h is not None:
+            _tensors += (h,)
+        super().__init__(*_tensors, dtype=dtype, device=device)
+        self.J = self[2]
+        self.h = self[1]

--- a/src/simulated_bifurcation/optimizer/simulated_bifurcation_optimizer.py
+++ b/src/simulated_bifurcation/optimizer/simulated_bifurcation_optimizer.py
@@ -7,6 +7,7 @@ import torch
 from numpy import minimum
 from tqdm import tqdm
 
+from ..check_dtype import check_dtype
 from .environment import ENVIRONMENT
 from .simulated_bifurcation_engine import SimulatedBifurcationEngine
 from .stop_window import StopWindow
@@ -93,6 +94,7 @@ class SimulatedBifurcationOptimizer:
         self.timeout = timeout if timeout is not None else float("inf")
 
     def __reset(self, matrix: torch.Tensor, use_window: bool) -> None:
+        check_dtype(matrix.dtype)
         self.__init_progress_bars()
         self.__init_symplectic_integrator(matrix)
         self.__init_window(matrix, use_window)

--- a/src/simulated_bifurcation/optimizer/stop_window.py
+++ b/src/simulated_bifurcation/optimizer/stop_window.py
@@ -3,6 +3,8 @@ from typing import Tuple, Union
 import torch
 from tqdm import tqdm
 
+from ..check_dtype import check_dtype
+
 
 class StopWindow:
     """
@@ -20,6 +22,7 @@ class StopWindow:
         device: Union[str, torch.device],
         verbose: bool,
     ) -> None:
+        check_dtype(dtype)
         self.ising_tensor = ising_tensor
         self.n_spins = self.ising_tensor.shape[0]
         self.n_agents = n_agents

--- a/src/simulated_bifurcation/optimizer/symplectic_integrator.py
+++ b/src/simulated_bifurcation/optimizer/symplectic_integrator.py
@@ -2,6 +2,8 @@ from typing import Any, Tuple, Union
 
 import torch
 
+from ..check_dtype import check_dtype
+
 
 class SymplecticIntegrator:
     """
@@ -17,6 +19,7 @@ class SymplecticIntegrator:
         dtype: torch.dtype,
         device: Union[str, torch.device],
     ):
+        check_dtype(dtype)
         self.position = self.__init_oscillator(shape, dtype, device)
         self.momentum = self.__init_oscillator(shape, dtype, device)
         self.activation_function = activation_function

--- a/src/simulated_bifurcation/polynomial/polynomial.py
+++ b/src/simulated_bifurcation/polynomial/polynomial.py
@@ -66,6 +66,8 @@ class Polynomial:
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
     ) -> None:
+        if dtype is None:
+            dtype = torch.get_default_dtype()
         if len(_input) == 1 and isinstance(_input[0], Poly):
             self.__polynomial_map = PolynomialMap.from_expression(
                 _input[0], dtype=dtype, device=device

--- a/tests/core/test_ising.py
+++ b/tests/core/test_ising.py
@@ -14,7 +14,7 @@ h = torch.tensor([1, 0, -1], dtype=torch.float32)
 
 
 def test_init_ising_model_from_tensors():
-    ising = Ising(J, h)
+    ising = Ising(J, h, dtype=torch.float32)
     assert torch.equal(ising.J, J)
     assert torch.equal(ising.h, h)
     assert ising.linear_term
@@ -23,7 +23,7 @@ def test_init_ising_model_from_tensors():
 
 
 def test_init_ising_model_from_arrays():
-    ising = Ising(J.numpy(), h.numpy())
+    ising = Ising(J.numpy(), h.numpy(), dtype=torch.float32)
     assert torch.equal(ising.J, J)
     assert torch.equal(ising.h, h)
     assert ising.linear_term
@@ -32,7 +32,7 @@ def test_init_ising_model_from_arrays():
 
 
 def test_ising_without_linear_term():
-    ising = Ising(J)
+    ising = Ising(J, dtype=torch.float32)
     assert torch.equal(ising.J, J)
     assert torch.equal(ising.h, torch.zeros(3))
     assert not ising.linear_term
@@ -41,7 +41,7 @@ def test_ising_without_linear_term():
 
 
 def test_init_ising_with_null_h_vector():
-    ising = Ising(J, torch.zeros(3))
+    ising = Ising(J, torch.zeros(3), dtype=torch.float32)
     assert torch.equal(ising.J, J)
     assert torch.equal(ising.h, torch.zeros(3))
     assert not ising.linear_term
@@ -50,7 +50,7 @@ def test_init_ising_with_null_h_vector():
 
 
 def test_clip_vector_to_tensor():
-    ising = Ising(J, h)
+    ising = Ising(J, h, dtype=torch.float32)
     attached = ising.clip_vector_to_tensor()
     assert torch.equal(
         attached,
@@ -75,7 +75,7 @@ def test_simulated_bifurcation_tensor():
         ],
         dtype=torch.float32,
     )
-    ising = Ising(original)
+    ising = Ising(original, dtype=torch.float32)
     expected_result = torch.tensor(
         [
             [0, 3, 5],
@@ -88,7 +88,7 @@ def test_simulated_bifurcation_tensor():
 
 
 def test_negative_ising():
-    ising = Ising(J, h)
+    ising = Ising(J, h, dtype=torch.float32)
     negative_ising = -ising
     assert torch.equal(negative_ising.J, -J)
     assert torch.equal(negative_ising.h, -h)

--- a/tests/core/test_quadratic_polynomial.py
+++ b/tests/core/test_quadratic_polynomial.py
@@ -36,55 +36,55 @@ def test_build_polynomial_from_expression():
     with pytest.raises(
         QuadraticPolynomialError, match="Expected a degree 2 polynomial, got 1."
     ):
-        QuadraticPolynomial(poly(x + y + z))
+        QuadraticPolynomial(poly(x + y + z), dtype=torch.float32)
 
     with pytest.raises(
         QuadraticPolynomialError, match="Expected a degree 2 polynomial, got 3."
     ):
-        QuadraticPolynomial(poly(x**3))
+        QuadraticPolynomial(poly(x**3), dtype=torch.float32)
 
 
 def test_build_polynomial_from_tensor():
     polynomial = QuadraticPolynomial(quadratic, dtype=torch.float32)
     assert isinstance(polynomial, QuadraticPolynomial)
     assert torch.equal(quadratic, polynomial[2])
-    assert torch.equal(torch.zeros(3), polynomial[1])
-    assert torch.equal(torch.tensor(0), polynomial[0])
+    assert torch.equal(torch.zeros(3, dtype=torch.float32), polynomial[1])
+    assert torch.equal(torch.tensor(0, dtype=torch.float32), polynomial[0])
 
     polynomial = QuadraticPolynomial(quadratic, linear, dtype=torch.float32)
     assert isinstance(polynomial, QuadraticPolynomial)
     assert torch.equal(quadratic, polynomial[2])
     assert torch.equal(linear, polynomial[1])
-    assert torch.equal(torch.tensor(0), polynomial[0])
+    assert torch.equal(torch.tensor(0, dtype=torch.float32), polynomial[0])
 
     polynomial = QuadraticPolynomial(linear, quadratic, dtype=torch.float32)
     assert isinstance(polynomial, QuadraticPolynomial)
     assert torch.equal(quadratic, polynomial[2])
     assert torch.equal(linear, polynomial[1])
-    assert torch.equal(torch.tensor(0), polynomial[0])
+    assert torch.equal(torch.tensor(0, dtype=torch.float32), polynomial[0])
 
     polynomial = QuadraticPolynomial(quadratic, 2, dtype=torch.float32)
     assert isinstance(polynomial, QuadraticPolynomial)
     assert torch.equal(quadratic, polynomial[2])
-    assert torch.equal(torch.zeros(3), polynomial[1])
+    assert torch.equal(torch.zeros(3, dtype=torch.float32), polynomial[1])
     assert torch.equal(constant, polynomial[0])
 
     polynomial = QuadraticPolynomial(2, quadratic, dtype=torch.float32)
     assert isinstance(polynomial, QuadraticPolynomial)
     assert torch.equal(quadratic, polynomial[2])
-    assert torch.equal(torch.zeros(3), polynomial[1])
+    assert torch.equal(torch.zeros(3, dtype=torch.float32), polynomial[1])
     assert torch.equal(constant, polynomial[0])
 
     polynomial = QuadraticPolynomial(quadratic, constant, dtype=torch.float32)
     assert isinstance(polynomial, QuadraticPolynomial)
     assert torch.equal(quadratic, polynomial[2])
-    assert torch.equal(torch.zeros(3), polynomial[1])
+    assert torch.equal(torch.zeros(3, dtype=torch.float32), polynomial[1])
     assert torch.equal(constant, polynomial[0])
 
     polynomial = QuadraticPolynomial(constant, quadratic, dtype=torch.float32)
     assert isinstance(polynomial, QuadraticPolynomial)
     assert torch.equal(quadratic, polynomial[2])
-    assert torch.equal(torch.zeros(3), polynomial[1])
+    assert torch.equal(torch.zeros(3, dtype=torch.float32), polynomial[1])
     assert torch.equal(constant, polynomial[0])
 
     polynomial = QuadraticPolynomial(quadratic, linear, constant, dtype=torch.float32)
@@ -163,12 +163,12 @@ def test_build_polynomial_from_tensor():
         ValueError,
         match="Declaring twice the same degree is ambiguous. Got two tensors for degree 2.",
     ):
-        QuadraticPolynomial(quadratic, quadratic)
+        QuadraticPolynomial(quadratic, quadratic, dtype=torch.float32)
 
     with pytest.raises(
         QuadraticPolynomialError, match="Expected a degree 2 polynomial, got 1."
     ):
-        QuadraticPolynomial(linear)
+        QuadraticPolynomial(linear, dtype=torch.float32)
 
     with pytest.raises(
         QuadraticPolynomialError, match="Expected a degree 2 polynomial, got 3."
@@ -181,7 +181,7 @@ def test_build_polynomial_from_tensor():
         PolynomialMapTensorDimensionError,
         match="All dimensions of the tensor must be equal.",
     ):
-        QuadraticPolynomial(torch.zeros((3, 2)))
+        QuadraticPolynomial(torch.zeros((3, 2)), dtype=torch.float32)
 
 
 def test_build_polynomial_with_wrong_domain():
@@ -189,7 +189,7 @@ def test_build_polynomial_with_wrong_domain():
         TypeError,
         match="Expected tensors or arrays, got <class 'str'>.",
     ):
-        QuadraticPolynomial("Hello world!")
+        QuadraticPolynomial("Hello world!", dtype=torch.float32)
 
 
 matrix = torch.tensor(
@@ -420,10 +420,12 @@ def test_wrong_domain_to_ising():
 
 
 def test_wrong_domain_cnvert_spin():
-    ising = Ising(quadratic)
+    ising = Ising(quadratic, dtype=torch.float32)
     ising.computed_spins = torch.ones(3, 3)
     with pytest.raises(ValueError):
-        QuadraticPolynomial(quadratic).convert_spins(ising, domain="Hello world!")
+        QuadraticPolynomial(quadratic, dtype=torch.float32).convert_spins(
+            ising, domain="Hello world!"
+        )
 
 
 def test_evaluate_polynomial():

--- a/tests/models/test_ising_model.py
+++ b/tests/models/test_ising_model.py
@@ -5,8 +5,8 @@ from src.simulated_bifurcation.models import Ising
 
 def test_ising():
     torch.manual_seed(42)
-    J = torch.tensor([[0, -2, 3], [-2, 0, 1], [3, 1, 0]])
-    h = torch.tensor([1, -4, 2])
+    J = torch.tensor([[0, -2, 3], [-2, 0, 1], [3, 1, 0]], dtype=torch.float32)
+    h = torch.tensor([1, -4, 2], dtype=torch.float32)
     model = Ising(J, h, dtype=torch.float32, device=torch.device("cpu"))
     spin_vector, value = model.optimize(
         agents=10,

--- a/tests/models/test_qubo.py
+++ b/tests/models/test_qubo.py
@@ -5,13 +5,17 @@ from src.simulated_bifurcation.models import QUBO
 
 def test_qubo():
     torch.manual_seed(42)
-    Q = torch.tensor([[1, -2, 3], [0, -4, 1], [0, 0, 2]])
+    Q = torch.tensor([[1, -2, 3], [0, -4, 1], [0, 0, 2]], dtype=torch.float32)
     model = QUBO(Q, dtype=torch.float32)
     binary_vector, value = model.minimize(agents=10, verbose=False, best_only=True)
-    assert torch.equal(torch.tensor([1.0, 1.0, 0.0]), binary_vector)
+    assert torch.equal(
+        torch.tensor([1.0, 1.0, 0.0], dtype=torch.float32), binary_vector
+    )
     assert -5.0 == value
     binary_vector, value = model.maximize(agents=10, verbose=False, best_only=True)
-    assert torch.equal(torch.tensor([1.0, 0.0, 1.0]), binary_vector)
+    assert torch.equal(
+        torch.tensor([1.0, 0.0, 1.0], dtype=torch.float32), binary_vector
+    )
     assert 6.0 == value
 
 
@@ -26,7 +30,8 @@ def test_lp_problem_formulated_as_qubo():
             [0, 0, 0, 2, -P, 0],
             [0, 0, 0, 0, 4.5, -P],
             [0, 0, 0, 0, 0, 3],
-        ]
+        ],
+        dtype=torch.float32,
     )
     binary_vector, objective_value = QUBO(Q, dtype=torch.float32).maximize(
         agents=10, verbose=False

--- a/tests/test_check_dtype.py
+++ b/tests/test_check_dtype.py
@@ -1,0 +1,24 @@
+import pytest
+import torch
+
+from simulated_bifurcation.check_dtype import check_dtype
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_check_float_dtype(dtype: torch.dtype):
+    assert check_dtype(dtype) == dtype
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.float16, torch.int8, torch.int16, torch.int32, torch.int64]
+)
+def test_check_int_or_float16_dtype(dtype: torch.dtype):
+    with pytest.raises(
+        ValueError,
+        match="Only torch.float32 and torch.float64 are accepted for Simulated Bifurcation computations.",
+    ):
+        check_dtype(dtype)
+
+
+def test_none_dtype():
+    assert check_dtype(None) == torch.float32

--- a/tests/test_simulated_bifurcation.py
+++ b/tests/test_simulated_bifurcation.py
@@ -12,7 +12,7 @@ matrix = torch.tensor(
     dtype=torch.float32,
 )
 vector = torch.tensor([1, 2, -3], dtype=torch.float32)
-constant = 1
+constant = torch.tensor(1, dtype=torch.float32)
 
 x, y, z = symbols("x y z")
 expression = poly(


### PR DESCRIPTION
# 💬 Pull Request Description

Based on #41, a reflexion was carried out regarding the difference between the models' dtype and the computation dtype. 

Because the oscillators in the SB backend are in [-1, 1], the backend computation dtype must be a float. Besides, some key PyTorch methods are not available for `float16` so only `float32` and `float64` are considered.

Thus, the core Ising model and the SB optimizer can only run on `float32` or `float64` dtype, any other dtype will raise a `ValueError`.

However, `QuadraticPolynomial`s can still be of any dtype. When such a polynomial is converted to an Ising model:
- if the `QuadraticPolynomial`'s dtype is `float32` or `float64`, this dtype is used for the equivalent Ising model
- for any other dtype, the `float32` dtype will be used for the Ising model by default

Once the optimal spins are retrieved by the polynomial at the end of the optimization and converted to integer values according to the optimization domain, the tensors are converted to the polynomial's dtype.

When passing the `dtype` parameter to the `sb.maximize`/`sb.minimize` functions, the dtype will be used as the `QuadraticPolynomial`'s dtype and by extension as the optimization dtype if the dtype id float (otherwise, it will be  `float32`). 

Finally, for `Polynomial`s, if the `dtype` and/or `device` parameters are set to None, the default dtype and/or device of PyTorch will be used.

# ✔️ Check list

- [x] The code matches the styling rules
- [x] The new code is covered by relevant tests
- [x] Documentation was added

# 🚀 New features

None.

# 🐞 Bug fixes

None.

# 📣 Supplementary information

None.