### PR TITLE
Force backend computation dtype to float

### DIFF
--- a/src/simulated_bifurcation/core/ising.py
+++ b/src/simulated_bifurcation/core/ising.py
@@ -88,9 +88,14 @@ class Ising:
         self,
         J: Union[torch.Tensor, ndarray],
         h: Union[torch.Tensor, ndarray, None] = None,
-        dtype: Optional[torch.dtype] = None,
+        dtype: Optional[torch.dtype] = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
     ) -> None:
+        if dtype not in [torch.float32, torch.float64]:
+            raise ValueError(
+                "Only torch.float32 and torch.float64 are supported for Simulated Bifurcation"
+                f" computations but got {dtype}."
+            )
         self.dimension = J.shape[0]
         if isinstance(J, ndarray):
             J = torch.from_numpy(J)

--- a/src/simulated_bifurcation/models/abc_model.py
+++ b/src/simulated_bifurcation/models/abc_model.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import torch
 
@@ -34,7 +34,9 @@ class ABCModel(ABC, QuadraticPolynomial):
         use_window: bool = True,
         sampling_period: int = 50,
         convergence_threshold: int = 50,
-        timeout: Optional[float] = None
+        timeout: Optional[float] = None,
+        dtype: torch.dtype = torch.float32,
+        device: Optional[Union[str, torch.device]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         return super().optimize(
             self.domain,
@@ -49,6 +51,8 @@ class ABCModel(ABC, QuadraticPolynomial):
             sampling_period=sampling_period,
             convergence_threshold=convergence_threshold,
             timeout=timeout,
+            dtype=dtype,
+            device=device,
         )
 
     def minimize(
@@ -63,7 +67,9 @@ class ABCModel(ABC, QuadraticPolynomial):
         use_window: bool = True,
         sampling_period: int = 50,
         convergence_threshold: int = 50,
-        timeout: Optional[float] = None
+        timeout: Optional[float] = None,
+        dtype: torch.dtype = torch.float32,
+        device: Optional[Union[str, torch.device]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         return self.optimize(
             agents,
@@ -77,6 +83,8 @@ class ABCModel(ABC, QuadraticPolynomial):
             sampling_period=sampling_period,
             convergence_threshold=convergence_threshold,
             timeout=timeout,
+            dtype=dtype,
+            device=device,
         )
 
     def maximize(
@@ -91,7 +99,9 @@ class ABCModel(ABC, QuadraticPolynomial):
         use_window: bool = True,
         sampling_period: int = 50,
         convergence_threshold: int = 50,
-        timeout: Optional[float] = None
+        timeout: Optional[float] = None,
+        dtype: torch.dtype = torch.float32,
+        device: Optional[Union[str, torch.device]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         return self.optimize(
             agents,
@@ -105,4 +115,6 @@ class ABCModel(ABC, QuadraticPolynomial):
             sampling_period=sampling_period,
             convergence_threshold=convergence_threshold,
             timeout=timeout,
+            dtype=dtype,
+            device=device,
         )

--- a/src/simulated_bifurcation/models/ising.py
+++ b/src/simulated_bifurcation/models/ising.py
@@ -25,6 +25,9 @@ class Ising(ABCModel):
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
     ) -> None:
-        super().__init__(-0.5 * J, h, dtype=dtype, device=device)
-        self.J = J
-        self.h = h
+        _tensors = (-0.5 * J,)
+        if h is not None:
+            _tensors += (h,)
+        super().__init__(*_tensors, dtype=dtype, device=device)
+        self.J = self[2]
+        self.h = self[1]

--- a/src/simulated_bifurcation/polynomial/polynomial.py
+++ b/src/simulated_bifurcation/polynomial/polynomial.py
@@ -66,6 +66,8 @@ class Polynomial:
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
     ) -> None:
+        if dtype is None:
+            dtype = torch.get_default_dtype()
         if len(_input) == 1 and isinstance(_input[0], Poly):
             self.__polynomial_map = PolynomialMap.from_expression(
                 _input[0], dtype=dtype, device=device

--- a/src/simulated_bifurcation/simulated_bifurcation.py
+++ b/src/simulated_bifurcation/simulated_bifurcation.py
@@ -159,7 +159,7 @@ def build_model(
 def optimize(
     *polynomial: PolynomialLike,
     domain: str = "spin",
-    dtype: Optional[torch.dtype] = None,
+    dtype: Optional[torch.dtype] = torch.float32,
     device: Optional[Union[str, torch.device]] = None,
     agents: int = 128,
     max_steps: int = 10_000,
@@ -430,6 +430,8 @@ def optimize(
         sampling_period=sampling_period,
         convergence_threshold=convergence_threshold,
         timeout=timeout,
+        dtype=dtype,
+        device=device,
     )
     return result, evaluation
 
@@ -437,7 +439,7 @@ def optimize(
 def minimize(
     *polynomial: PolynomialLike,
     domain: str = "spin",
-    dtype: Optional[torch.dtype] = None,
+    dtype: Optional[torch.dtype] = torch.float32,
     device: Optional[Union[str, torch.device]] = None,
     agents: int = 128,
     max_steps: int = 10_000,
@@ -700,7 +702,7 @@ def minimize(
 def maximize(
     *polynomial: PolynomialLike,
     domain: str = "spin",
-    dtype: Optional[torch.dtype] = None,
+    dtype: Optional[torch.dtype] = torch.float32,
     device: Optional[Union[str, torch.device]] = None,
     agents: int = 128,
     max_steps: int = 10_000,

--- a/tests/core/test_ising.py
+++ b/tests/core/test_ising.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from src.simulated_bifurcation.core import Ising
@@ -95,3 +96,11 @@ def test_negative_ising():
     assert negative_ising.linear_term
     assert len(negative_ising) == 3
     assert negative_ising.dimension == 3
+
+
+def test_non_float_ising():
+    with pytest.raises(
+        ValueError,
+        match="Only torch.float32 and torch.float64 are supported for Simulated Bifurcation computations but got torch.int8.",
+    ):
+        Ising(J, dtype=torch.int8)


### PR DESCRIPTION
# 💬 Pull Request Description

Based on #41, a reflexion was carried out regarding the difference between the models' dtype and the computation dtype. 

Because the oscillators in the SB backend are in [-1, 1], the backend computation dtype must be a float. Besides, some key PyTorch methods are not available for `float16` so only `float32` and `float64` are considered.

Thus, the core Ising model which is used by the SB optimizer can only be defined with `float32` (default) or `float64` dtype, any other dtype will raise a `ValueError`.

However, `QuadraticPolynomial`s can still be of any dtype. When such a polynomial is converted to an Ising model, a new `dtype` argument must be passed to indicate the dtype of the Ising model that will be generated. When calling `QuadraticPolynomial::optimize`, `QuadraticPolynomial::maximize` or `QuadraticPolynomial::minimize`, a `dtype` argument must also be provided to indicate the backend dtype (for equivalent Ising model and thus SB optimizer computations).

Once the optimal spins are retrieved by the polynomial at the end of the optimization and converted to integer values according to the optimization domain, the tensors are converted to the polynomial's dtype.

When passing the `dtype` parameter to the `sb.maximize`/`sb.minimize` functions, the dtype will be used as the `QuadraticPolynomial`'s dtype and as the optimization dtype. If not provided, `float32` will be used. 

> We concluded that two dtype parameters are not useful for `sb.maximize` and `sb.minimize` since the model is only used for optimization and not retrieved in any manner. Thus, using the computation dtype as the model's dtype is acceptable. If users really want to create the model with a specific dtype, they can first build it with `build_model` and then call one of three optimization methods.

Finally, for `Polynomial`s, if the `dtype` and/or `device` parameters are set to None, the default dtype and/or device of PyTorch will be used.

# ✔️ Check list

- [x] The code matches the styling rules
- [x] The new code is covered by relevant tests
- [x] Documentation was added

# 🚀 New features

None.

# 🐞 Bug fixes

None.

# 📣 Supplementary information

None.