### PR TITLE
Remove max steps in timeout test

### DIFF
--- a/tests/optimizer/test_optimizer.py
+++ b/tests/optimizer/test_optimizer.py
@@ -170,7 +170,7 @@ def test_timeout():
     h = torch.tensor([1, 0, -2], dtype=torch.float32)
     ising = Ising(J, h)
     optimizer = SimulatedBifurcationOptimizer(
-        128, 100000, 3.0, SimulatedBifurcationEngine.HbSB, True, 50, 50
+        128, None, 3.0, SimulatedBifurcationEngine.HbSB, True, 50, 50
     )
     optimizer.run_integrator(ising.as_simulated_bifurcation_tensor(), False)
     assert optimizer.simulation_time > 3.0


### PR DESCRIPTION
# 💬 Pull Request Description

CI breaks on Mac OS because of timeout test not working properly.

# ✔️ Check list

- [x] The code matches the styling rules
- [x] The new code is covered by relevant tests
- [x] Documentation was added

# 🚀 New features

None.

# 🐞 Bug fixes

Max steps removed in timeout test.

# 📣 Supplementary information

None.