### PR TITLE
Allow optimization variables to be on different domains

### DIFF
--- a/src/simulated_bifurcation/core/optimization_domain.py
+++ b/src/simulated_bifurcation/core/optimization_domain.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class OptimizationDomain(Enum):
+    SPIN = "spin"
+    BINARY = "binary"
+    INTEGER = "integer"

--- a/src/simulated_bifurcation/core/quadratic_polynomial.py
+++ b/src/simulated_bifurcation/core/quadratic_polynomial.py
@@ -238,7 +238,7 @@ class QuadraticPolynomial(Polynomial):
             or more formally, any string matching the regular expression
             `^int[1-9][0-9]*$`.
         ValueError
-            If `domain` is used as a list of optimizatio domains with a
+            If `domain` is used as a list of optimization domains with a
             length different from the number of variables.
 
         """
@@ -311,7 +311,7 @@ class QuadraticPolynomial(Polynomial):
             or more formally, any string matching the regular expression
             `^int[1-9][0-9]*$`.
         ValueError
-            If `domain` is used as a list of optimizatio domains with a
+            If `domain` is used as a list of optimization domains with a
             length different from the number of variables.
         """
         variables = self.__get_variables(domain=domain)

--- a/src/simulated_bifurcation/core/quadratic_polynomial.py
+++ b/src/simulated_bifurcation/core/quadratic_polynomial.py
@@ -190,7 +190,16 @@ class QuadraticPolynomial(Polynomial):
         evaluation = torch.squeeze(quadratic_term, -1) + affine_term
         return evaluation
 
-    def to_ising(self, domain: str) -> Ising:
+    def __get_variables(self, domain: Union[str, List[str]]) -> List[Variable]:
+        if isinstance(domain, str):
+            return [Variable.from_str(domain) for _ in range(self.n_variables)]
+        if len(domain) != self.n_variables:
+            raise ValueError(
+                f"Expected {self.n_variables} domains to be provided, got {len(domain)}."
+            )
+        return [Variable.from_str(variable_domain) for variable_domain in domain]
+
+    def to_ising(self, domain: Union[str, List[str]]) -> Ising:
         """
         Generate an equivalent Ising model of the problem.
         The notion of equivalence means that finding the ground
@@ -226,7 +235,7 @@ class QuadraticPolynomial(Polynomial):
             following regular expression: ^int[1-9][0-9]*$.
 
         """
-        variables = [Variable.from_str(domain) for _ in range(self.n_variables)]
+        variables = self.__get_variables(domain=domain)
         spin_identity_vector = QuadraticPolynomial.__spin_identity_vector(
             variables=variables, dtype=self.dtype, device=self.device
         )
@@ -267,7 +276,9 @@ class QuadraticPolynomial(Polynomial):
             self.device,
         )
 
-    def convert_spins(self, ising: Ising, domain: str) -> Optional[torch.Tensor]:
+    def convert_spins(
+        self, ising: Ising, domain: Union[str, List[str]]
+    ) -> Optional[torch.Tensor]:
         """
         Retrieves information from the optimized equivalent Ising model.
         Returns the best found vector if `ising.ground_state` is not `None`.
@@ -302,7 +313,7 @@ class QuadraticPolynomial(Polynomial):
             a positive integer, or more formally, any string matching the
             following regular expression: ^int[1-9][0-9]*$.
         """
-        variables = [Variable.from_str(domain) for _ in range(self.n_variables)]
+        variables = self.__get_variables(domain=domain)
         spin_identity_vector = QuadraticPolynomial.__spin_identity_vector(
             variables=variables, dtype=self.dtype, device=self.device
         )
@@ -324,7 +335,7 @@ class QuadraticPolynomial(Polynomial):
 
     def optimize(
         self,
-        domain: str,
+        domain: Union[str, List[str]],
         agents: int = 128,
         max_steps: int = 10000,
         best_only: bool = True,
@@ -441,7 +452,7 @@ class QuadraticPolynomial(Polynomial):
 
     def minimize(
         self,
-        domain: str,
+        domain: Union[str, List[str]],
         agents: int = 128,
         max_steps: int = 10000,
         best_only: bool = True,
@@ -545,7 +556,7 @@ class QuadraticPolynomial(Polynomial):
 
     def maximize(
         self,
-        domain: str,
+        domain: Union[str, List[str]],
         agents: int = 128,
         max_steps: int = 10000,
         best_only: bool = True,

--- a/src/simulated_bifurcation/core/quadratic_polynomial.py
+++ b/src/simulated_bifurcation/core/quadratic_polynomial.py
@@ -220,6 +220,9 @@ class QuadraticPolynomial(Polynomial):
               2^n - 1 inclusive. "int..." represents any string starting with
               "int" and followed by a positive integer n, e.g. "int3", "int42".
 
+            If the variables have different domains, a list of string with the
+            same length as the number of variables can be provided instead.
+
         Returns
         -------
         Ising
@@ -229,10 +232,14 @@ class QuadraticPolynomial(Polynomial):
         Raises
         ------
         ValueError
-            If `domain` is not one of {"spin", "binary", "int..."}, where
-            "int..." designates any string starting with "int" and followed by
-            a positive integer, or more formally, any string matching the
-            following regular expression: ^int[1-9][0-9]*$.
+            If `domain` (or any domain in case a list is passed) is not one
+            of {"spin", "binary", "int..."}, where "int..." designates any
+            string starting with "int" and followed by a positive integer,
+            or more formally, any string matching the regular expression
+            `^int[1-9][0-9]*$`.
+        ValueError
+            If `domain` is used as a list of optimizatio domains with a
+            length different from the number of variables.
 
         """
         variables = self.__get_variables(domain=domain)
@@ -301,6 +308,9 @@ class QuadraticPolynomial(Polynomial):
               2^n - 1 inclusive. "int..." represents any string starting with
               "int" and followed by a positive integer n, e.g. "int3", "int42".
 
+            If the variables have different domains, a list of string with the
+            same length as the number of variables can be provided instead.
+
         Returns
         -------
         Tensor
@@ -308,10 +318,14 @@ class QuadraticPolynomial(Polynomial):
         Raises
         ------
         ValueError
-            If `domain` is not one of {"spin", "binary", "int..."}, where
-            "int..." designates any string starting with "int" and followed by
-            a positive integer, or more formally, any string matching the
-            following regular expression: ^int[1-9][0-9]*$.
+            If `domain` (or any domain in case a list is passed) is not one
+            of {"spin", "binary", "int..."}, where "int..." designates any
+            string starting with "int" and followed by a positive integer,
+            or more formally, any string matching the regular expression
+            `^int[1-9][0-9]*$`.
+        ValueError
+            If `domain` is used as a list of optimizatio domains with a
+            length different from the number of variables.
         """
         variables = self.__get_variables(domain=domain)
         spin_identity_vector = QuadraticPolynomial.__spin_identity_vector(

--- a/src/simulated_bifurcation/core/variable.py
+++ b/src/simulated_bifurcation/core/variable.py
@@ -1,0 +1,69 @@
+import re
+
+from .optimization_domain import OptimizationDomain
+
+
+class Variable:
+    INTEGER_REGEX = re.compile("^int[1-9][0-9]*$")
+    DOMAIN_ERROR = ValueError(
+        'Domain type must be one of "spin" or "binary", or be a string starting '
+        'with "int" and followed by a positive integer that represents '
+        "the number of bits required to encode the values of the domain. "
+        "More formally, it should match the following regular expression: "
+        '"^int[1-9][0-9]*$" (ex: "int7", "int42", ...).'
+    )
+
+    def __init__(self, domain_type: OptimizationDomain, encoding_bits: int) -> None:
+        if (
+            domain_type == OptimizationDomain.SPIN
+            or domain_type == OptimizationDomain.BINARY
+        ) and encoding_bits != 1:
+            raise ValueError(
+                "A spin or binary variable can only be encoded with one bit."
+            )
+        self.__domain_type = domain_type
+        self.__encoding_bits = encoding_bits
+
+    @property
+    def encoding_bits(self) -> int:
+        """
+        Number of bits required to encode the values of the variable.
+        """
+        return self.__encoding_bits
+
+    @property
+    def is_spin(self) -> int:
+        """
+        Returns `True` is the variable is a spin variable, `False` otherwise.
+        """
+        return self.__domain_type == OptimizationDomain.SPIN
+
+    @staticmethod
+    def from_str(domain: str):
+        """
+        Instantiates a Variable from a domain type name
+
+        Parameters
+        ----------
+        domain : str
+            Domain type. Must be `"spin"`, `"binary"` of match the regular expression
+            `"^int[1-9][0-9]*$"`. For integers, the number following `"int"` corresponds
+            to the number of bits required to encode the variable possible values.
+
+        Returns
+        -------
+        Variable
+            Variable defined on the input domain.
+
+        Raises
+        ------
+        ValueError
+            If the domain is not a valid one (spin, binary or integer).
+        """
+        if domain == "spin":
+            return Variable(OptimizationDomain.SPIN, 1)
+        if domain == "binary":
+            return Variable(OptimizationDomain.BINARY, 1)
+        if Variable.INTEGER_REGEX.match(domain) is None:
+            raise Variable.DOMAIN_ERROR
+        return Variable(OptimizationDomain.INTEGER, int(domain[3:]))

--- a/src/simulated_bifurcation/core/variable.py
+++ b/src/simulated_bifurcation/core/variable.py
@@ -41,7 +41,7 @@ class Variable:
     @staticmethod
     def from_str(domain: str):
         """
-        Instantiates a Variable from a domain type name
+        Instantiates a Variable from a domain type name.
 
         Parameters
         ----------

--- a/src/simulated_bifurcation/models/abc_model.py
+++ b/src/simulated_bifurcation/models/abc_model.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import torch
 
@@ -19,7 +19,7 @@ class ABCModel(ABC, QuadraticPolynomial):
 
     """
 
-    domain: str
+    domain: Union[str, List[str]]
 
     def optimize(
         self,

--- a/src/simulated_bifurcation/simulated_bifurcation.py
+++ b/src/simulated_bifurcation/simulated_bifurcation.py
@@ -210,6 +210,8 @@ def optimize(
           2^n - 1 inclusive. "int..." represents any string starting with
           "int" and followed by a positive integer n, e.g. "int3", "int42".
 
+        If the variables have different domains, a list of string with the
+        same length as the number of variables can be provided instead.
     dtype : torch.dtype, default=torch.float32, keyword-only
         Data-type used for running the computations in the SB algorithm.
     device : str | torch.device, default="cpu", keyword-only
@@ -277,10 +279,14 @@ def optimize(
     Raises
     ------
     ValueError
-        If `domain` is not one of {"spin", "binary", "int..."}, where
-        "int..." designates any string starting with "int" and followed by
-        a positive integer, or more formally, any string matching the
-        following regular expression: ^int[1-9][0-9]*$.
+        If `domain` (or any domain in case a list is passed) is not one
+        of {"spin", "binary", "int..."}, where "int..." designates any
+        string starting with "int" and followed by a positive integer,
+        or more formally, any string matching the regular expression
+        `^int[1-9][0-9]*$`.
+    ValueError
+        If `domain` is used as a list of optimizatio domains with a
+        length different from the number of variables.
 
     Warns
     -----
@@ -487,6 +493,8 @@ def minimize(
           2^n - 1 inclusive. "int..." represents any string starting with
           "int" and followed by a positive integer n, e.g. "int3", "int42".
 
+        If the variables have different domains, a list of string with the
+        same length as the number of variables can be provided instead.
     dtype : torch.dtype, default=torch.float32, keyword-only
         Data-type used for running the computations in the SB algorithm.
     device : str | torch.device, default="cpu", keyword-only
@@ -551,10 +559,14 @@ def minimize(
     Raises
     ------
     ValueError
-        If `domain` is not one of {"spin", "binary", "int..."}, where
-        "int..." designates any string starting with "int" and followed by
-        a positive integer, or more formally, any string matching the
-        following regular expression: ^int[1-9][0-9]*$.
+        If `domain` (or any domain in case a list is passed) is not one
+        of {"spin", "binary", "int..."}, where "int..." designates any
+        string starting with "int" and followed by a positive integer,
+        or more formally, any string matching the regular expression
+        `^int[1-9][0-9]*$`.
+    ValueError
+        If `domain` is used as a list of optimizatio domains with a
+        length different from the number of variables.
 
     Warns
     -----
@@ -750,6 +762,8 @@ def maximize(
           2^n - 1 inclusive. "int..." represents any string starting with
           "int" and followed by a positive integer n, e.g. "int3", "int42".
 
+        If the variables have different domains, a list of string with the
+        same length as the number of variables can be provided instead.
     dtype : torch.dtype, default=torch.float32, keyword-only
         Data-type used for running the computations in the SB algorithm.
     device : str | torch.device, default="cpu", keyword-only
@@ -814,10 +828,14 @@ def maximize(
     Raises
     ------
     ValueError
-        If `domain` is not one of {"spin", "binary", "int..."}, where
-        "int..." designates any string starting with "int" and followed by
-        a positive integer, or more formally, any string matching the
-        following regular expression: ^int[1-9][0-9]*$.
+        If `domain` (or any domain in case a list is passed) is not one
+        of {"spin", "binary", "int..."}, where "int..." designates any
+        string starting with "int" and followed by a positive integer,
+        or more formally, any string matching the regular expression
+        `^int[1-9][0-9]*$`.
+    ValueError
+        If `domain` is used as a list of optimizatio domains with a
+        length different from the number of variables.
 
     Warns
     -----

--- a/src/simulated_bifurcation/simulated_bifurcation.py
+++ b/src/simulated_bifurcation/simulated_bifurcation.py
@@ -285,7 +285,7 @@ def optimize(
         or more formally, any string matching the regular expression
         `^int[1-9][0-9]*$`.
     ValueError
-        If `domain` is used as a list of optimizatio domains with a
+        If `domain` is used as a list of optimization domains with a
         length different from the number of variables.
 
     Warns
@@ -565,7 +565,7 @@ def minimize(
         or more formally, any string matching the regular expression
         `^int[1-9][0-9]*$`.
     ValueError
-        If `domain` is used as a list of optimizatio domains with a
+        If `domain` is used as a list of optimization domains with a
         length different from the number of variables.
 
     Warns
@@ -834,7 +834,7 @@ def maximize(
         or more formally, any string matching the regular expression
         `^int[1-9][0-9]*$`.
     ValueError
-        If `domain` is used as a list of optimizatio domains with a
+        If `domain` is used as a list of optimization domains with a
         length different from the number of variables.
 
     Warns

--- a/src/simulated_bifurcation/simulated_bifurcation.py
+++ b/src/simulated_bifurcation/simulated_bifurcation.py
@@ -28,7 +28,7 @@ models:
 
 """
 
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import torch
 
@@ -158,7 +158,7 @@ def build_model(
 
 def optimize(
     *polynomial: PolynomialLike,
-    domain: str = "spin",
+    domain: Union[str, List[str]] = "spin",
     dtype: Optional[torch.dtype] = None,
     device: Optional[Union[str, torch.device]] = None,
     agents: int = 128,
@@ -436,7 +436,7 @@ def optimize(
 
 def minimize(
     *polynomial: PolynomialLike,
-    domain: str = "spin",
+    domain: Union[str, List[str]] = "spin",
     dtype: Optional[torch.dtype] = None,
     device: Optional[Union[str, torch.device]] = None,
     agents: int = 128,
@@ -699,7 +699,7 @@ def minimize(
 
 def maximize(
     *polynomial: PolynomialLike,
-    domain: str = "spin",
+    domain: Union[str, List[str]] = "spin",
     dtype: Optional[torch.dtype] = None,
     device: Optional[Union[str, torch.device]] = None,
     agents: int = 128,

--- a/tests/core/test_variable.py
+++ b/tests/core/test_variable.py
@@ -1,0 +1,72 @@
+import pytest
+
+from simulated_bifurcation.core.optimization_domain import OptimizationDomain
+from simulated_bifurcation.core.variable import Variable
+
+
+def test_init_spin_variable():
+    spin_variable = Variable(OptimizationDomain.SPIN, 1)
+    assert spin_variable.is_spin
+    assert spin_variable.encoding_bits == 1
+
+
+def test_init_spin_variable_from_string():
+    spin_variable = Variable.from_str("spin")
+    assert spin_variable.is_spin
+    assert spin_variable.encoding_bits == 1
+
+
+def test_init_spin_variable_with_sevral_encoding_bits():
+    with pytest.raises(
+        ValueError, match="A spin or binary variable can only be encoded with one bit."
+    ):
+        Variable(OptimizationDomain.SPIN, 2)
+
+
+def test_init_binary_variable():
+    binary_variable = Variable(OptimizationDomain.BINARY, 1)
+    assert not binary_variable.is_spin
+    assert binary_variable.encoding_bits == 1
+
+
+def test_init_binary_variable_from_string():
+    binary_variable = Variable.from_str("binary")
+    assert not binary_variable.is_spin
+    assert binary_variable.encoding_bits == 1
+
+
+def test_init_binary_variable_with_sevral_encoding_bits():
+    with pytest.raises(
+        ValueError, match="A spin or binary variable can only be encoded with one bit."
+    ):
+        Variable(OptimizationDomain.BINARY, 2)
+
+
+@pytest.mark.parametrize("encoding_bits", [1, 3, 17, 42, 100])
+def test_init_integer_variable(encoding_bits: int):
+    int_variable = Variable(OptimizationDomain.INTEGER, encoding_bits)
+    assert not int_variable.is_spin
+    assert int_variable.encoding_bits == encoding_bits
+
+
+@pytest.mark.parametrize("encoding_bits", [1, 3, 17, 42, 100])
+def test_init_integer_variable_from_string(encoding_bits: int):
+    int_variable = Variable.from_str(f"int{encoding_bits}")
+    assert not int_variable.is_spin
+    assert int_variable.encoding_bits == encoding_bits
+
+
+def test_init_integer_variable_from_wrong_string_pattern():
+    expected_error_message = (
+        r"Domain type must be one of \"spin\" or \"binary\", or be a string starting "
+        r"with \"int\" and followed by a positive integer that represents "
+        r"the number of bits required to encode the values of the domain\. "
+        r"More formally, it should match the following regular expression: "
+        r"\"\^int\[1-9\]\[0-9\]\*\$\" \(ex: \"int7\", \"int42\", \.\.\.\)\."
+    )
+    with pytest.raises(ValueError, match=expected_error_message):
+        Variable.from_str("int0")
+    with pytest.raises(ValueError, match=expected_error_message):
+        Variable.from_str("int1.5")
+    with pytest.raises(ValueError, match=expected_error_message):
+        Variable.from_str("Hello world!")


### PR DESCRIPTION
# 💬 Pull Request Description

This PR allows the optimization of quadratic polynomials to occur on different domains at the same time. For instance, let us consider a model with 4 variables:

- $x_1$ which is a spin
- $x_2$ which is binary
- $x_3$ which is a 2-bits encoded integer variable
- $x_4$ which is a 5-bits encoded integer variable

Previously, all variables had to be defined on the same domain but it is now possible to specify **one domain per variable**. To do so, instead of a string, the `domain` argument of the optimization functions must be passed as a list of string with the same length as the number of variables. For the previous example, the input would be:

```python
sb.minimize(model, domain=["spin", "binary", "int2", "int5"])
```

> **Note:** if the domain is passed as a string, for example `"spin"`, then all variables will be considered of this very type, i.e. spin.

**Example**

```python
sb.minimize(model, domain="spin")  # All variables are optimized as spins, i.e. on {-1, 1}
sb.minimize(model, domain=["spin", "binary", "int2", "int5"])  # Variables will respectively be optimized on {-1, 1}, {0, 1}, [0, 3] and [0, 31]
```

> ⚠️ If the length of  `domain` does not match the dimension of the optimization model, a `ValueError` will be raised.

# ✔️ Check list

- [x] The code matches the styling rules
- [x] The new code is covered by relevant tests
- [x] Documentation was added

# 🚀 New features

Possibility to define on optimization domain per variable.

# 🐞 Bug fixes

None.

# 📣 Supplementary information

The quadratic-polynomial-to-Ising conversions have been unified in a single formula. The math behind this new formula is explained below:

> TODO: Add math