### PR TITLE
Force NumPy < 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ package_version = "1.3.0.dev0"
 
 
 dependencies = [
-    "numpy",
+    "numpy<2",
     "sympy",
     "torch>=2.0.1",
     "tqdm",


### PR DESCRIPTION
Numpy 2 will be supported in a future release (1.3.0, 1.4.0 or 2.0.0) so Python 3.8 will be discarded. For now, we must keep numpy < 2.