### PR TITLE
Initial energy tensor device the same as device defined in class

### DIFF
--- a/src/simulated_bifurcation/optimizer/stop_window.py
+++ b/src/simulated_bifurcation/optimizer/stop_window.py
@@ -66,7 +66,9 @@ class StopWindow:
         return torch.zeros(self.n_agents, device=self.device, dtype=dtype)
 
     def __init_energies(self) -> None:
-        self.energies = torch.tensor([float("inf") for _ in range(self.n_agents)],device=self.device)
+        self.energies = torch.tensor(
+            [float("inf") for _ in range(self.n_agents)], device=self.device
+        )
 
     def __init_tensors(self) -> None:
         self.stability = self.__init_tensor(torch.int16)

--- a/src/simulated_bifurcation/optimizer/stop_window.py
+++ b/src/simulated_bifurcation/optimizer/stop_window.py
@@ -66,7 +66,7 @@ class StopWindow:
         return torch.zeros(self.n_agents, device=self.device, dtype=dtype)
 
     def __init_energies(self) -> None:
-        self.energies = torch.tensor([float("inf") for _ in range(self.n_agents)])
+        self.energies = torch.tensor([float("inf") for _ in range(self.n_agents)],device=self.device)
 
     def __init_tensors(self) -> None:
         self.stability = self.__init_tensor(torch.int16)


### PR DESCRIPTION
# 💬 Pull Request Description

This PR, specifies the device of initial energy tensor to be the same as the one defined while initializing `StopWindow` class.

# ✔️ Check list

_Before you open the pull request, make sure the following requirements are met._

- [x] The code matches the styling rules
- [x] The new code is covered by relevant tests
- [x] Documentation was added

# 🐞 Bug fixes

This pull request fixes the bug reported in issue #73, which happens when trying to call the `minimize` method using `device=cuda`. The bug arises due to the fact that inital energy tensor device differs from that of the one defined in `StopWindow` class in `stop_window.py`. Here, I fixed the problem by initializing the tensor with the device defined in the class.
# 📣 Supplementary information