### PR TITLE
Use `tqdm.auto.tqdm` for optimal progressbars display

### DIFF
--- a/src/simulated_bifurcation/optimizer/simulated_bifurcation_optimizer.py
+++ b/src/simulated_bifurcation/optimizer/simulated_bifurcation_optimizer.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 
 import torch
 from numpy import minimum
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from .environment import ENVIRONMENT
 from .simulated_bifurcation_engine import SimulatedBifurcationEngine

--- a/src/simulated_bifurcation/optimizer/stop_window.py
+++ b/src/simulated_bifurcation/optimizer/stop_window.py
@@ -1,7 +1,7 @@
 from typing import Tuple, Union
 
 import torch
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 
 class StopWindow:


### PR DESCRIPTION
# 💬 Pull Request Description

Though the progressbars display was optimized for terminals, they appeared oddly in Jupyter notebooks with the same progressbar being displayed again and again each time it was updated.

Using `from tqdm.auto import tqdm` instead of `from tqdm import tqdm` fixed this and the display in notebooks is better visually.

# ✔️ Check list

- [x] The code matches the styling rules
- [x] The new code is covered by relevant tests
- [x] Documentation was added

# 🚀 New features

None.

# 🐞 Bug fixes

Bad progressbars display in Jupyter notebooks.

# 📣 Supplementary information

None.