### PR TITLE
Cleaning/force float dtypes

### DIFF
--- a/docs/main_features/quadratic_models.md
+++ b/docs/main_features/quadratic_models.md
@@ -56,7 +56,7 @@ sb.maximize(p, domain="spin")
 
 A quadratic model is given a PyTorch's dtype that defines the type of its coefficients. When the polynomial is evaluated, the output values are typed using the same dtype.
 
-> ⚠️ The model's dtype is not used for optimization computations. A specific parameter called `dtype` serves this purpose in the optimization methods. For more details, see the [page](simulated_bifurcation_optimizer.md) dedicated to parameters.
+> The model's dtype is also used for optimization computations.
 
 ### Model device
 

--- a/src/simulated_bifurcation/core/ising.py
+++ b/src/simulated_bifurcation/core/ising.py
@@ -24,6 +24,7 @@ import torch
 from numpy import ndarray
 
 from ..optimizer import SimulatedBifurcationEngine, SimulatedBifurcationOptimizer
+from .utils import safe_get_device, safe_get_dtype
 
 # Workaround because `Self` type is only available in Python >= 3.11
 SelfIsing = TypeVar("SelfIsing", bound="Ising")
@@ -91,15 +92,8 @@ class Ising(object):
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
     ) -> None:
-        self._dtype = torch.float32 if dtype is None else dtype
-        self._device = (
-            torch.get_default_device() if device is None else torch.device(device)
-        )
-
-        if self._dtype not in [torch.float32, torch.float64]:
-            raise ValueError(
-                f"Simulated Bifurcation optimization can only be carried out with torch.float32 or torch.float64 dtypes, but got {dtype}."
-            )
+        self._dtype = safe_get_dtype(dtype)
+        self._device = safe_get_device(device)
 
         if isinstance(J, ndarray):
             J = torch.from_numpy(J)

--- a/src/simulated_bifurcation/core/quadratic_polynomial.py
+++ b/src/simulated_bifurcation/core/quadratic_polynomial.py
@@ -30,6 +30,8 @@ from sympy import Poly
 from .ising import Ising
 from .variable import Variable
 
+from .utils import safe_get_dtype, safe_get_device
+
 INTEGER_REGEX = re.compile("^int[1-9][0-9]*$")
 DOMAIN_ERROR = ValueError(
     f'Input type must be one of "spin" or "binary", or be a string starting'
@@ -160,10 +162,8 @@ class QuadraticPolynomial(object):
         dtype: Optional[torch.dtype] = None,
         device: Optional[Union[str, torch.device]] = None,
     ):
-        self._dtype = torch.get_default_dtype() if dtype is None else dtype
-        self._device = (
-            torch.get_default_device() if device is None else torch.device(device)
-        )
+        self._dtype = safe_get_dtype(dtype)
+        self._device = safe_get_device(device)
         self.sb_result = None
 
         if len(polynomial_data) == 1 and isinstance(polynomial_data[0], Poly):
@@ -421,15 +421,12 @@ class QuadraticPolynomial(object):
         self, optimized_spins: torch.Tensor, domain: Union[str, List[str]]
     ) -> Optional[torch.Tensor]:
         """
-        Retrieves information from the optimized equivalent Ising model.
-        Returns the best found vector if `ising.ground_state` is not `None`.
-        Returns `None` otherwise.
+        Convert optimized spins back to the optimization domain.
 
         Parameters
         ----------
-        ising : IsingCore
-            Equivalent Ising model to optimized with the Simulated
-            Bifurcation algorithm.
+        optimized_spins : torch.Tensor
+            Optimized spins to convert.
         domain : str
             Domain over which the optimization is done.
 

--- a/src/simulated_bifurcation/core/quadratic_polynomial.py
+++ b/src/simulated_bifurcation/core/quadratic_polynomial.py
@@ -272,10 +272,7 @@ class QuadraticPolynomial(object):
             value,
             torch.unsqueeze(self._quadratic_coefficients, 0),
         )
-        affine_term = (
-            value @ self._linear_coefficients
-            + self._bias
-        )
+        affine_term = value @ self._linear_coefficients + self._bias
         evaluation = torch.squeeze(quadratic_term, -1) + affine_term
         return evaluation
 
@@ -321,9 +318,7 @@ class QuadraticPolynomial(object):
             )
         return [Variable.from_str(variable_domain) for variable_domain in domain]
 
-    def to_ising(
-        self, domain: Union[str, List[str]]
-    ) -> Ising:
+    def to_ising(self, domain: Union[str, List[str]]) -> Ising:
         """
         Generate an equivalent Ising model of the problem.
         The notion of equivalence means that finding the ground

--- a/src/simulated_bifurcation/core/quadratic_polynomial.py
+++ b/src/simulated_bifurcation/core/quadratic_polynomial.py
@@ -28,9 +28,8 @@ import torch
 from sympy import Poly
 
 from .ising import Ising
+from .utils import safe_get_device, safe_get_dtype
 from .variable import Variable
-
-from .utils import safe_get_dtype, safe_get_device
 
 INTEGER_REGEX = re.compile("^int[1-9][0-9]*$")
 DOMAIN_ERROR = ValueError(

--- a/src/simulated_bifurcation/core/utils.py
+++ b/src/simulated_bifurcation/core/utils.py
@@ -1,0 +1,17 @@
+from typing import Optional, Union
+
+import torch
+
+
+def safe_get_dtype(dtype: Optional[torch.dtype]) -> torch.dtype:
+    if dtype is None:
+        return torch.float32
+    elif dtype == torch.float32 or dtype == torch.float64:
+        return dtype
+    raise ValueError(
+        "The Simulated Bifurcation algorithm can only run with a torch.float32 or a torch.float64 dtype."
+    )
+
+
+def safe_get_device(device: Optional[Union[str, torch.device]]) -> torch.device:
+    return torch.get_default_device() if device is None else torch.device(device)

--- a/src/simulated_bifurcation/models/abc_model.py
+++ b/src/simulated_bifurcation/models/abc_model.py
@@ -35,7 +35,6 @@ class ABCModel(ABC, QuadraticPolynomial):
         sampling_period: int = 50,
         convergence_threshold: int = 50,
         timeout: Optional[float] = None,
-        dtype: Optional[torch.dtype] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         return super().optimize(
             domain=self.domain,
@@ -50,7 +49,6 @@ class ABCModel(ABC, QuadraticPolynomial):
             sampling_period=sampling_period,
             convergence_threshold=convergence_threshold,
             timeout=timeout,
-            dtype=dtype,
         )
 
     def minimize(
@@ -66,7 +64,6 @@ class ABCModel(ABC, QuadraticPolynomial):
         sampling_period: int = 50,
         convergence_threshold: int = 50,
         timeout: Optional[float] = None,
-        dtype: Optional[torch.dtype] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         return self.optimize(
             agents=agents,
@@ -80,7 +77,6 @@ class ABCModel(ABC, QuadraticPolynomial):
             sampling_period=sampling_period,
             convergence_threshold=convergence_threshold,
             timeout=timeout,
-            dtype=dtype,
         )
 
     def maximize(
@@ -96,7 +92,6 @@ class ABCModel(ABC, QuadraticPolynomial):
         sampling_period: int = 50,
         convergence_threshold: int = 50,
         timeout: Optional[float] = None,
-        dtype: Optional[torch.dtype] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         return self.optimize(
             agents=agents,
@@ -110,5 +105,4 @@ class ABCModel(ABC, QuadraticPolynomial):
             sampling_period=sampling_period,
             convergence_threshold=convergence_threshold,
             timeout=timeout,
-            dtype=dtype,
         )

--- a/src/simulated_bifurcation/simulated_bifurcation.py
+++ b/src/simulated_bifurcation/simulated_bifurcation.py
@@ -131,10 +131,6 @@ def build_model(
       >>> poly(points)
       tensor([0, 3, 1, 2])
 
-    Migrate the polynomial to the GPU for faster computation
-
-      >>> poly.to(device="cuda")
-
     Maximize this polynomial over {0, 1, ..., 14, 15} x {0, 1, ..., 14, 15}
     (outputs are located on the GPU)
 
@@ -442,7 +438,6 @@ def optimize(
         sampling_period=sampling_period,
         convergence_threshold=convergence_threshold,
         timeout=timeout,
-        dtype=dtype,
     )
     return result, evaluation
 

--- a/tests/core/test_ising.py
+++ b/tests/core/test_ising.py
@@ -4,7 +4,7 @@ import torch
 
 from src.simulated_bifurcation.core import Ising
 
-from ..test_utils import DEVICES, FLOAT_DTYPES, INT_DTYPES
+from ..test_utils import DEVICES, DTYPES
 
 J = [
     [1, 2, 3],
@@ -20,7 +20,7 @@ h = [1, 0, -1]
         (use_tensor, use_linear_term, dtype, device)
         for use_tensor in [True, False]
         for use_linear_term in [True, False]
-        for dtype in [*FLOAT_DTYPES, None]
+        for dtype in [*DTYPES, None]
         for device in [*DEVICES, None]
     ],
 )
@@ -44,22 +44,6 @@ def test_init_ising(
     assert ising._dimension == 3
     assert ising._dtype == torch.float32 if dtype is None else dtype
     assert ising._device == torch.get_default_device() if device is None else device
-
-
-@pytest.mark.parametrize(
-    "dtype, device",
-    [(dtype, device) for dtype in INT_DTYPES for device in DEVICES],
-)
-def test_init_ising_with_wrong_dtype(dtype: torch.dtype, device: torch.device):
-    with pytest.raises(
-        ValueError,
-        match=f"Simulated Bifurcation optimization can only be carried out with torch.float32 or torch.float64 dtypes, but got {dtype}.",
-    ):
-        Ising(
-            torch.tensor(J, dtype=torch.float32, device=device),
-            dtype=dtype,
-            device=device,
-        )
 
 
 def test_init_ising_with_non_2_dimensional_J():
@@ -88,7 +72,7 @@ def test_init_ising_with_inconsistant_h_shape():
     [
         (use_linear_term, dtype, device)
         for use_linear_term in [True, False]
-        for dtype in FLOAT_DTYPES
+        for dtype in DTYPES
         for device in DEVICES
     ],
 )
@@ -121,7 +105,7 @@ def test_as_simulated_bifurcation_tensor(
     [
         (use_linear_term, dtype, device)
         for use_linear_term in [True, False]
-        for dtype in FLOAT_DTYPES
+        for dtype in DTYPES
         for device in DEVICES
     ],
 )

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,0 +1,34 @@
+import pytest
+import torch
+
+from src.simulated_bifurcation.core.utils import safe_get_device, safe_get_dtype
+
+
+def test_get_default_dtype():
+    assert torch.float32 == safe_get_dtype(None)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_get_proper_dtype(dtype: torch.dtype):
+    assert dtype == safe_get_dtype(dtype)
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.float16, torch.int8, torch.int16, torch.int32, torch.int64]
+)
+def test_get_unauthorized_dtype(dtype: torch.dtype):
+    with pytest.raises(
+        ValueError,
+        match="The Simulated Bifurcation algorithm can only run with a torch.float32 or a torch.float64 dtype.",
+    ):
+        safe_get_dtype(dtype)
+
+
+def test_get_default_device():
+    assert torch.get_default_device() == safe_get_device(None)
+
+
+def test_get_device():
+    cpu = torch.device("cpu")
+    assert cpu == safe_get_device(cpu)
+    assert cpu == safe_get_device("cpu")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,6 @@
 import torch
 
-INT_DTYPES = [torch.int8, torch.int16, torch.int32, torch.int64]
-FLOAT_DTYPES = [torch.float32, torch.float64]
-DTYPES = FLOAT_DTYPES + INT_DTYPES
+DTYPES = [torch.float32, torch.float64]
 
 DEVICES = (
     [torch.device("cpu"), torch.device("cuda")]


### PR DESCRIPTION
# 💬 Pull Request Description

Because of cuda incompatibilities (see #91) polynomial operations needed to be done using `torch.float32` or `torch.float64` dtypes. For simplicity's sake, polynomial can only be defined using one of these two dtypes and there is no longer a difference between the computation dtype and the model dtype.

# ✔️ Check list

_Before you open the pull request, make sure the following requirements are met._

- [ ] The code matches the styling rules
- [ ] The new code is covered by relevant tests
- [ ] Documentation was added

# 🚀 New features

None.

# 🐞 Bug fixes

None.

# 📣 Supplementary information

Breaking change if users were relying on integer dtypes for their models.